### PR TITLE
Fix ProviderName to be "baremetal".

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	ProviderName = "solas"
+	ProviderName = "baremetal"
 	// HostAnnotation is the key for an annotation that should go on a Machine to
 	// reference what BareMetalHost it corresponds to.
 	HostAnnotation = "metal3.io/BareMetalHost"


### PR DESCRIPTION
This constant came from the sample provider implementation in
cluster-api docs.  It was missed when changing the sample to use
"baremetal" everywhere instead of the sample "solas" provider.