### PR TITLE
Reflect that userdata is optional in tests.

### DIFF
--- a/pkg/apis/baremetal/v1alpha1/baremetalmachineproviderspec_types.go
+++ b/pkg/apis/baremetal/v1alpha1/baremetalmachineproviderspec_types.go
@@ -61,11 +61,6 @@ func (s *BareMetalMachineProviderSpec) IsValid() error {
 	if s.Image.Checksum == "" {
 		missing = append(missing, "Image.Checksum")
 	}
-	if s.UserData == nil {
-		missing = append(missing, "UserData")
-	} else if s.UserData.Name == "" {
-		missing = append(missing, "UserData.Name")
-	}
 	if len(missing) > 0 {
 		return fmt.Errorf("Missing fields from ProviderSpec: %v", missing)
 	}

--- a/pkg/apis/baremetal/v1alpha1/baremetalmachineproviderspec_types_test.go
+++ b/pkg/apis/baremetal/v1alpha1/baremetalmachineproviderspec_types_test.go
@@ -95,8 +95,8 @@ func TestProviderSpecIsValid(t *testing.T) {
 					Checksum: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2.md5sum",
 				},
 			},
-			ErrorExpected: true,
-			Name:          "missing UserData",
+			ErrorExpected: false,
+			Name:          "missing optional UserData",
 		},
 		{
 			Spec: BareMetalMachineProviderSpec{
@@ -108,8 +108,8 @@ func TestProviderSpecIsValid(t *testing.T) {
 					Namespace: "otherns",
 				},
 			},
-			ErrorExpected: true,
-			Name:          "missing UserData.Name",
+			ErrorExpected: false,
+			Name:          "missing optional UserData.Name",
 		},
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -297,7 +297,7 @@ func (a *Actuator) setHostSpec(ctx context.Context, host *bmh.BareMetalHost, mac
 	}
 	host.Spec.Online = true
 	host.Spec.UserData = config.UserData
-	if host.Spec.UserData.Namespace == "" {
+	if host.Spec.UserData != nil && host.Spec.UserData.Namespace == "" {
 		host.Spec.UserData.Namespace = machine.Namespace
 	}
 	return a.client.Update(ctx, host)


### PR DESCRIPTION
We made a late change to the providerSpec to specify that the userData
field was optional.  This patch updates the test code to reflect this,
as well.

I also spotted one other place that assumed userData was specified in
the machine actuator.