### PR TITLE
Update RBAC from upstream docs.

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -9,11 +9,6 @@ rules:
   resources:
   - machines
   - machines/status
-  - machinedeployments
-  - machinedeployments/status
-  - machinesets
-  - machinesets/status
-  - machineclasses
   verbs:
   - get
   - list
@@ -25,8 +20,7 @@ rules:
 - apiGroups:
   - cluster.k8s.io
   resources:
-  - clusters
-  - clusters/status
+  - machineClasses
   verbs:
   - get
   - list

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -49,7 +49,7 @@ rules:
   - update
   - patch
 - apiGroups:
-  - baremetal.k8s.io
+  - baremetal.cluster.k8s.io
   resources:
   - baremetalmachineproviderspecs
   - baremetalmachineproviderstatuses

--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -46,8 +46,8 @@ const (
 )
 
 // Add RBAC rules to access cluster-api resources
-//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status;machinedeployments;machinedeployments/status;machinesets;machinesets/status;machineclasses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machineClasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes;events,verbs=get;list;watch;create;update;patch;delete
 
 // RBAC to access BareMetalHost resources from metal3.io

--- a/pkg/controller/add_machine.go
+++ b/pkg/controller/add_machine.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-//+kubebuilder:rbac:groups=baremetal.k8s.io,resources=baremetalmachineproviderspecs;baremetalmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=baremetal.cluster.k8s.io,resources=baremetalmachineproviderspecs;baremetalmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {


### PR DESCRIPTION
The cluster-api project has docs that describe how to build a
provider.  This patch syncs some recent changes to their documented
RBAC.

https://github.com/kubernetes-sigs/cluster-api/pull/947