### PR TITLE
Makefile: Add kubeubilder and kustomize checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 go:
   - "1.11.5"
 before_install:
-  - ./tools/install_kustomize.sh
+  - go get sigs.k8s.io/kustomize
   - ./tools/install_kubebuilder.sh
   - make generate
 env:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: testprereqs generate fmt vet unit
 .PHONY: testprereqs
 testprereqs:
 	@if [ ! -d /usr/local/kubebuilder ] ; then echo "kubebuilder not found.  See docs/dev/setup.md" && exit 1 ; fi
-	@if ! which kustomize >/dev/null 2>&1 ; then echo "kustomize not found.  See docs/dev/setup.md" && exit 1 ; fi
+	@if ! which kustomize >/dev/null 2>&1 ; then echo "Running 'go get sigs.k8s.io/kustomize'" && go get sigs.k8s.io/kustomize ; fi
 
 unit: manifests
 	go test ./pkg/... ./cmd/... -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,12 @@ build:
 all: test manager
 
 # Run tests
-test: generate fmt vet unit
+test: testprereqs generate fmt vet unit
+
+.PHONY: testprereqs
+testprereqs:
+	@if [ ! -d /usr/local/kubebuilder ] ; then echo "kubebuilder not found.  See docs/dev/setup.md" && exit 1 ; fi
+	@if ! which kustomize >/dev/null 2>&1 ; then echo "kustomize not found.  See docs/dev/setup.md" && exit 1 ; fi
 
 unit: manifests
 	go test ./pkg/... ./cmd/... -coverprofile cover.out

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -6,9 +6,7 @@ during development.
 ## Install kustomize
 
 ```bash
-eval $(go env)
-export GOPATH
-./tools/install_kustomize.sh
+go get sigs.k8s.io/kustomize
 ```
 
 ## Install kubebuilder

--- a/tools/install_kustomize.sh
+++ b/tools/install_kustomize.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -x
-mkdir -p $GOPATH/bin
-curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_linux_amd64 -o $GOPATH/bin/kustomize
-chmod +x $GOPATH/bin/kustomize


### PR DESCRIPTION
Generating manifests and running the test suite require kustomize and
kubebuilder.  Add a quick check for them to the Makefile to avoid less
obvious errors later if they are missing.

Closes issue #14.