### PR TITLE
Don't assume hardware details are available.

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -451,8 +451,8 @@ func (a *Actuator) applyMachineStatus(ctx context.Context, machine *machinev1.Ma
 func (a *Actuator) nodeAddresses(host *bmh.BareMetalHost) ([]corev1.NodeAddress, error) {
 	addrs := []corev1.NodeAddress{}
 
-	// If the host is nil, return an empty address array.
-	if host == nil {
+	// If the host is nil or we have no hw details, return an empty address array.
+	if host == nil || host.Status.HardwareDetails == nil {
 		return addrs, nil
 	}
 

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -897,6 +897,20 @@ func TestUpdateMachineStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			// machine status unchanged
+			Host: &bmh.BareMetalHost{},
+			Machine: &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mymachine",
+					Namespace: "myns",
+				},
+				Status: machinev1.MachineStatus{},
+			},
+			ExpectedMachine: machinev1.Machine{
+				Status: machinev1.MachineStatus{},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This patch fixes a crash due to assuming that hardware details will
always be available on a BareMetalHost object.  A test case has been
added for this, as well.

Fixes #82.