### PR TITLE
Delay Machine deletion until BaremetalHost deprovisioned

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"testing"
+	"time"
 
 	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
 	machinev1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	clustererror "sigs.k8s.io/cluster-api/pkg/controller/error"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
@@ -624,6 +626,7 @@ func TestDelete(t *testing.T) {
 		Host               *bmh.BareMetalHost
 		Machine            machinev1.Machine
 		ExpectedMachineRef *corev1.ObjectReference
+		ExpectedResult     error
 	}{
 		{
 			// machine ref should be removed
@@ -648,6 +651,7 @@ func TestDelete(t *testing.T) {
 					},
 				},
 			},
+			ExpectedResult: &clustererror.RequeueAfterError{},
 		},
 		{
 			// machine ref does not match, so it should not be removed
@@ -678,7 +682,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 		{
-			// no machine ref, so this is a no-op
+			// no machine ref, so wait for deprovisioning
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myhost",
@@ -694,6 +698,7 @@ func TestDelete(t *testing.T) {
 					},
 				},
 			},
+			ExpectedResult: &clustererror.RequeueAfterError{RequeueAfter: time.Second * 30},
 		},
 		{
 			// no host at all, so this is a no-op
@@ -723,8 +728,19 @@ func TestDelete(t *testing.T) {
 		}
 
 		err = actuator.Delete(context.TODO(), nil, &tc.Machine)
-		if err != nil {
-			t.Errorf("unexpected error %v", err)
+
+		var expectedResult bool
+		switch e := tc.ExpectedResult.(type) {
+		case nil:
+			expectedResult = (err == nil)
+		case *clustererror.RequeueAfterError:
+			var perr *clustererror.RequeueAfterError
+			if perr, expectedResult = err.(*clustererror.RequeueAfterError); expectedResult {
+				expectedResult = (*e == *perr)
+			}
+		}
+		if !expectedResult {
+			t.Errorf("unexpected error \"%v\" (expected \"%v\")", err, tc.ExpectedResult)
 		}
 		if tc.Host != nil {
 			key := client.ObjectKey{


### PR DESCRIPTION
In order to ensure that fencing works correctly, we can't allow the
Machine object to be deleted while there is still a chance that the
BaremetalHost is still powered on and running. Delay successful
completion of the deletion until the actuator has verified that the Host
cannot be online.

Closes #84