### PR TITLE
Use binary for kustomize instead of `go get`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 go:
   - "1.11.5"
 before_install:
-  - go get sigs.k8s.io/kustomize
+  - ./tools/install_kustomize.sh
   - ./tools/install_kubebuilder.sh
   - make generate
 env:

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -6,7 +6,9 @@ during development.
 ## Install kustomize
 
 ```bash
-go get sigs.k8s.io/kustomize
+eval $(go env)
+export GOPATH
+./tools/install_kustomize.sh
 ```
 
 ## Install kubebuilder

--- a/tools/install_kustomize.sh
+++ b/tools/install_kustomize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+mkdir -p $GOPATH/bin
+curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -o $GOPATH/bin/kustomize
+chmod +x $GOPATH/bin/kustomize


### PR DESCRIPTION
`go get` is broken.  The latest HEAD of kustomize needs go 1.12 or
later and uses `go install`.