### PR TITLE
Create and use a unit test image.

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN INSTALL_PKGS=" \
+      golang \
+      " && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+WORKDIR /tools
+COPY /tools /tools
+RUN ./install_kustomize.sh
+RUN ./install_kubebuilder.sh
+RUN mv kubebuilder /usr/local/.

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -5,19 +5,15 @@ set -eux
 IS_CONTAINER=${IS_CONTAINER:-false}
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-  TOP_DIR="${1:-$(pwd)}"
-  cd
-  "${TOP_DIR}"/tools/install_kustomize.sh
-  "${TOP_DIR}"/tools/install_kubebuilder.sh
-  mv kubebuilder /usr/local/.
-  cd "${TOP_DIR}"
+  eval "$(go env)"
+  cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-baremetal
   go test ./pkg/... ./cmd/... -coverprofile /cover.out
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-baremetal:ro,z" \
+    --volume "${PWD}:/root/go/src/github.com/metal3-io/cluster-api-provider-baremetal:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-baremetal \
-    registry.hub.docker.com/library/golang:1.12 \
-    /go/src/github.com/metal3-io/cluster-api-provider-baremetal/hack/unit.sh "${@}"
+    --workdir /root/go/src/github.com/metal3-io/cluster-api-provider-baremetal \
+    quay.io/metal3-io/capbm-unit \
+    /root/go/src/github.com/metal3-io/cluster-api-provider-baremetal/hack/unit.sh "${@}"
 fi;

--- a/tools/install_kubebuilder.sh
+++ b/tools/install_kubebuilder.sh
@@ -6,5 +6,6 @@ arch=amd64
 curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
 
 tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
+rm kubebuilder_${version}_linux_${arch}.tar.gz
 
 mv kubebuilder_${version}_linux_${arch} kubebuilder


### PR DESCRIPTION
Instead of installing kubebuilder and kustomize each time the unit
tests run in a container, just pre-install those in a container image.

Also update install_kubebuilder.sh to remove the downloaded tar.gz to
reduce the size of the resulting container image.