### PR TITLE
Make the unit test script work under prow.

### DIFF
--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -7,7 +7,7 @@ IS_CONTAINER=${IS_CONTAINER:-false}
 if [ "${IS_CONTAINER}" != "false" ]; then
   eval "$(go env)"
   cd "${GOPATH}"/src/github.com/metal3-io/cluster-api-provider-baremetal
-  go test ./pkg/... ./cmd/... -coverprofile /cover.out
+  go test ./pkg/... ./cmd/... -coverprofile "${ARTIFACTS}"/cover.out
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
The script prevoiusly failed under prow because / was read-only.  There is an ARTIFACTS env var where cover.out can be placed.  This will also result in cover.out being stored as a job artifact for review.