### PR TITLE
hack/govet: Set XDG_CACHE_HOME

### DIFF
--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -6,6 +6,7 @@ IS_CONTAINER=${IS_CONTAINER:-false}
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
+  export XDG_CACHE_HOME="/tmp/.cache"
   go vet "${TOP_DIR}"/pkg/... "${TOP_DIR}"/cmd/...
 else
   podman run --rm \


### PR DESCRIPTION
When running under prow, running "go vet" was trying to write to
/.cache, which doesn't work.  Try setting an env var to move this
under /tmp.