### PR TITLE
hack/unit: Set a default value for ARTIFACTS

### DIFF
--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -3,6 +3,7 @@
 set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
+ARTIFACTS=${ARTIFACTS:-/tmp}
 
 if [ "${IS_CONTAINER}" != "false" ]; then
   eval "$(go env)"


### PR DESCRIPTION
This variable is set by prow.  When running this script manually, have
it default to /tmp.