### PR TITLE
Modify unit test image in v1alpha2 to avoid path collision in prow

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,6 +1,6 @@
 FROM registry.hub.docker.com/library/golang:1.12
 
-WORKDIR /tools
-COPY /hack/tools /tools
+WORKDIR /usr/local/tools
+COPY /hack/tools /usr/local/tools
 RUN ./install_kustomize.sh
 RUN ./install_kubebuilder.sh

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -10,7 +10,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   mkdir /tmp/unit
   cp -r ./* /tmp/unit
   cd /tmp/unit
-  cp -r /tools/bin ./hack/tools
+  cp -r /usr/local/tools/bin ./hack/tools
   make test
 else
   podman run --rm \


### PR DESCRIPTION
Changing the path used to install kubebuilder and kustomize in capbm-unit image v1alpha2