### PR TITLE
[v1alpha2] Fix paths issue to run unit tests in v1alpha2 capbm-unit image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ testprereqs: $(KUBEBUILDER) $(KUSTOMIZE)
 
 .PHONY: test
 test: testprereqs generate fmt lint ## Run tests
-	go test -v ./api/... ./controllers/... ./baremetal/... -coverprofile /cover.out
+	go test -v ./api/... ./controllers/... ./baremetal/... -coverprofile ./cover.out
 
 .PHONY: test-integration
 test-integration: ## Run integration tests

--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,6 +1,9 @@
 FROM registry.hub.docker.com/library/golang:1.12
 
-WORKDIR /usr/local/tools
-COPY /hack/tools /usr/local/tools
-RUN ./install_kustomize.sh
-RUN ./install_kubebuilder.sh
+WORKDIR /usr/local/kubebuilder
+COPY /hack/tools /usr/local/kubebuilder/
+RUN mkdir -p /tmp/unittests && \
+    mkdir -p /tmp/unittests/hack/tools && \
+    ./install_kustomize.sh && \
+    ./install_kubebuilder.sh && \
+    cp -r /usr/local/kubebuilder/bin /tmp/unittests/hack/tools

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -7,10 +7,9 @@ IS_CONTAINER=${IS_CONTAINER:-false}
 if [ "${IS_CONTAINER}" != "false" ]; then
   #TODO Temporary hack : Remove after the image is fixed
   exit 0
-  mkdir /tmp/unit
-  cp -r ./* /tmp/unit
-  cd /tmp/unit
-  cp -r /usr/local/tools/bin ./hack/tools
+  export XDG_CACHE_HOME=/tmp/.cache
+  cp -r ./* /tmp/unittests
+  cd /tmp/unittests
   make test
 else
   podman run --rm \


### PR DESCRIPTION
- change go build cache path to a writable folder
- copy kubebuilder execs in two location in capbm-unit image
- modify the unit tests script accordingly