### PR TITLE
[v1alpha2] Remove v1alpha2 unit test hack and change tmp dir 

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -2,8 +2,5 @@ FROM registry.hub.docker.com/library/golang:1.12
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/
-RUN mkdir -p /tmp/unittests && \
-    mkdir -p /tmp/unittests/hack/tools && \
-    ./install_kustomize.sh && \
-    ./install_kubebuilder.sh && \
-    cp -r /usr/local/kubebuilder/bin /tmp/unittests/hack/tools
+RUN ./install_kustomize.sh && \
+    ./install_kubebuilder.sh

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -5,11 +5,11 @@ set -eux
 IS_CONTAINER=${IS_CONTAINER:-false}
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-  #TODO Temporary hack : Remove after the image is fixed
-  exit 0
   export XDG_CACHE_HOME=/tmp/.cache
-  cp -r ./* /tmp/unittests
-  cd /tmp/unittests
+  mkdir /tmp/unit
+  cp -r ./* /tmp/unit
+  cp -r /usr/local/kubebuilder/bin /tmp/unit/hack/tools
+  cd /tmp/unit
   make test
 else
   podman run --rm \


### PR DESCRIPTION
- a hack was added as long as the unit test job was broken, fixed now
- remove the creation of tmp dir in image due to permission issue