### PR TITLE
V1alpha2 Use CAPI release-0.2 branch to avoid v1alpha3 issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ manifests: generate-manifests $(KUSTOMIZE)
 		-o examples/provider-components/provider-components-baremetal.yaml
 	$(KUSTOMIZE) build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/config/default/?ref=master" \
 		-o examples/provider-components/provider-components-kubeadm.yaml
-	$(KUSTOMIZE) build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=master" \
+	$(KUSTOMIZE) build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=release-0.2" \
 		-o examples/provider-components/provider-components-cluster-api.yaml
 
 unit: manifests

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -98,13 +98,11 @@ kustomize build "${SOURCE_DIR}/machinedeployment" | envsubst >> "${MACHINEDEPLOY
 echo "Generated ${MACHINEDEPLOYMENT_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-# kustomize build "github.com/kubernetes-sigs/cluster-api//config/default/?ref=master" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
-kustomize build "${SOURCE_DIR}/../../cluster-api/config/default" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=release-0.2" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate Kubeadm Bootstrap Provider components file.
-# kustomize build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm//config/default/?ref=master" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
-kustomize build "${SOURCE_DIR}/../../cluster-api-bootstrap-provider-kubeadm/config/default" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
+kustomize build "github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/config/default/?ref=master" > "${COMPONENTS_KUBEADM_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_KUBEADM_GENERATED_FILE}"
 
 # Generate BAREMETAL Infrastructure Provider components file.

--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -3,5 +3,5 @@
 [[ -f bin/kustomize ]] && exit 0
 
 mkdir -p ./bin
-curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_linux_amd64 -o ./bin/kustomize
+curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.2.3/kustomize_kustomize.v3.2.3_linux_amd64 -o ./bin/kustomize
 chmod +x ./bin/kustomize


### PR DESCRIPTION
CAPI has moved to v1alpha3 and will remove v1alpha2 types. We'll be using the branch release-0.2 before we move to v1alpha3.

Co-authored-by: Jan Tilles <jan.tilles@est.tech>