### PR TITLE
Remove unneeded CAPD functions

### DIFF
--- a/baremetal/cluster_manager.go
+++ b/baremetal/cluster_manager.go
@@ -96,11 +96,6 @@ func (s *ClusterManager) Create(ctx context.Context) error {
 	return nil
 }
 
-// UpdateConfiguration updates the external cluster manager configuration with new control plane nodes.
-func (s *ClusterManager) UpdateConfiguration() error {
-	return nil
-}
-
 // APIEndpoints returns the cluster manager IP address
 func (s *ClusterManager) APIEndpoints() ([]capbm.APIEndpoint, error) {
 	//Get IP address from spec, which gets it from posted cr yaml

--- a/baremetal/machine_manager.go
+++ b/baremetal/machine_manager.go
@@ -144,16 +144,6 @@ func (mgr *MachineManager) Close() error {
 	return mgr.patchHelper.Patch(context.TODO(), mgr.BareMetalMachine)
 }
 
-// ExecBootstrap runs bootstrap on a node, this is generally `kubeadm <init|join>`
-func (mgr *MachineManager) ExecBootstrap(data string) error {
-	return nil
-}
-
-// KubeadmReset will run `kubeadm reset` on the machine.
-func (mgr *MachineManager) KubeadmReset() error {
-	return nil
-}
-
 // Create creates a machine and is invoked by the Machine Controller
 func (mgr *MachineManager) Create(ctx context.Context) (string, error) {
 	mgr.Log.Info("Creating machine")


### PR DESCRIPTION
Kubeadmreset is not supported, will be part of CAPI control plane
management, and execBoostrap was a replacement for cloud-init in CAPD