### PR TITLE
various minor fixes

### DIFF
--- a/baremetal/machine_manager.go
+++ b/baremetal/machine_manager.go
@@ -218,10 +218,6 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 		return err
 	}
 
-	if err := m.updateMachineStatus(ctx, host); err != nil {
-		return err
-	}
-
 	m.Log.Info("Finished creating machine")
 	return nil
 }

--- a/controllers/baremetalmachine_controller.go
+++ b/controllers/baremetalmachine_controller.go
@@ -156,11 +156,12 @@ func (r *BareMetalMachineReconciler) reconcileNormal(ctx context.Context,
 
 	// if the machine is already provisioned, return
 	if machineMgr.BareMetalMachine.Spec.ProviderID != nil && machineMgr.BareMetalMachine.Status.Ready {
-		return ctrl.Result{}, nil
+		err := machineMgr.Update(ctx)
+		return ctrl.Result{}, err
 	}
 
 	// Make sure bootstrap data is available and populated.
-	if machineMgr.Machine.Spec.Bootstrap.Data == nil {
+	if !machineMgr.Machine.Status.BootstrapReady {
 		log.Info("Waiting for the Bootstrap provider controller to set bootstrap data")
 		return ctrl.Result{}, nil
 	}
@@ -190,7 +191,8 @@ func (r *BareMetalMachineReconciler) reconcileNormal(ctx context.Context,
 		machineMgr.SetReady()
 	}
 
-	return ctrl.Result{}, nil
+	err = machineMgr.Update(ctx)
+	return ctrl.Result{}, err
 }
 
 func (r *BareMetalMachineReconciler) reconcileDelete(ctx context.Context,

--- a/examples/metal3crds/metal3.io_baremetalhosts.yaml
+++ b/examples/metal3crds/metal3.io_baremetalhosts.yaml
@@ -45,8 +45,6 @@ spec:
     - bmhost
     singular: baremetalhost
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       description: BareMetalHost is the Schema for the baremetalhosts API
@@ -236,9 +234,10 @@ spec:
                       type: string
                     clockMegahertz:
                       description: ClockSpeed is a clock speed in MHz
-                      format: int64
-                      type: integer
+                      format: double
+                      type: number
                     count:
+                      format: int64
                       type: integer
                     flags:
                       items:

--- a/examples/metal3plane/hosts.yaml
+++ b/examples/metal3plane/hosts.yaml
@@ -17,6 +17,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.10:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f1e
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -27,6 +90,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.11:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f10
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -37,6 +163,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.12:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f11
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -47,6 +236,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.13:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f12
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -57,6 +309,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.14:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f13
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -67,6 +382,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.15:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f14
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -77,7 +455,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.16:6233
     credentialsName: demo-externally-provisioned-secret
-
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f15
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -88,7 +528,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.17:6233
     credentialsName: demo-externally-provisioned-secret
-
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f16
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -99,7 +601,69 @@ spec:
   bmc:
     address: ipmi://192.168.122.18:6233
     credentialsName: demo-externally-provisioned-secret
-
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f17
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -110,3 +674,66 @@ spec:
   bmc:
     address: ipmi://192.168.122.19:6233
     credentialsName: demo-externally-provisioned-secret
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2494.222
+      count: 4
+      flags:
+      - aes
+      model: Intel Xeon E3-12xx v2 (Ivy Bridge)
+    firmware:
+      bios:
+        date: 04/01/2014
+        vendor: SeaBIOS
+        version: 1.10.2-1ubuntu1
+    ramMebibytes: 8192
+    storage:
+    - hctl: "6:0:0:0"
+      model: QEMU HARDDISK
+      name: /dev/sda
+      rotational: true
+      serialNumber: drive-scsi0-0-0-0
+      sizeBytes: 53687091200
+      vendor: QEMU
+    systemVendor:
+      manufacturer: QEMU
+      productName: Standard PC (Q35 + ICH9, 2009)
+      serialNumber: ""
+    hostname: master-0
+    nics:
+    - ip: 172.22.0.11
+      mac: 00:28:19:1f:79:4d
+      model: 0x1af4 0x0001
+      name: eth0
+      pxe: true
+      speedGbps: 0
+      vlanId: 0
+    - ip: 192.168.111.20
+      mac: 00:28:19:1f:79:4f
+      model: 0x1af4 0x0001
+      name: eth1
+      pxe: false
+      speedGbps: 0
+      vlanId: 0
+  hardwareProfile: unknown
+  operationalStatus: OK
+  poweredOn: false
+  triedCredentials:
+    credentials:
+      name: demo-externally-provisioned-secret
+      namespace: default
+    credentialsVersion: "879"
+  provisioning:
+    ID: be02cfb3-7b24-47c7-b9b8-d69207d86f18
+    image:
+      checksum: http://172.22.0.1/images/centos-updated.qcow2.md5sum
+      url: http://172.22.0.1/images/centos-updated.qcow2
+    state: provisioned

--- a/go.mod
+++ b/go.mod
@@ -3,25 +3,16 @@ module sigs.k8s.io/cluster-api-provider-baremetal
 go 1.13
 
 require (
-	github.com/coreos/etcd v3.3.15+incompatible // indirect
-	github.com/coreos/go-oidc v2.1.0+incompatible // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/go-openapi/validate v0.19.2 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
-	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/metal3-io/baremetal-operator v0.0.0-20191004200613-f048f3bc5f05
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
-	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/spf13/cobra v0.0.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
@@ -31,17 +22,11 @@ require (
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	golang.org/x/tools v0.0.0-20191017101817-846f856e7d71 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
-	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 // indirect
-	google.golang.org/grpc v1.23.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/square/go-jose.v2 v2.2.2 // indirect
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-	k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269 // indirect
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a
 	sigs.k8s.io/cluster-api v0.2.7
 	sigs.k8s.io/controller-runtime v0.3.1-0.20191029211253-40070e2a1958
-	sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca // indirect
 )


### PR DESCRIPTION
- call update on machine after providerID change to ensure it is
  called on change
- call update on machine when already provisioned to reflect
  the update that triggered the reconcile
- add bmh in the machine controller tests
- add status to BMO fake CRs