### PR TITLE
Set node providerID on target cluster

### DIFF
--- a/api/v1alpha2/baremetalcluster_types.go
+++ b/api/v1alpha2/baremetalcluster_types.go
@@ -33,7 +33,8 @@ const (
 
 // BareMetalClusterSpec defines the desired state of BareMetalCluster.
 type BareMetalClusterSpec struct {
-	APIEndpoint string `json:"apiEndpoint"`
+	APIEndpoint     string `json:"apiEndpoint"`
+	NoCloudProvider bool   `json:"noCloudProvider,omitempty"`
 }
 
 // APIEndPointError represents error in the APIEndPoint in BareMetalCluster.Spec

--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -676,7 +676,7 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 		node.Spec.ProviderID = providerID
 		_, err = corev1Remote.Nodes().Update(&node)
 		if err != nil {
-			return errors.Wrap(err, "unable to get update node for baremetal host")
+			return errors.Wrap(err, "unable to update node for baremetal host")
 		}
 	}
 	return nil

--- a/baremetal/remote/remote.go
+++ b/baremetal/remote/remote.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewClusterClient creates a new ClusterClient.
+func NewClusterClient(c client.Client, cluster *clusterv1.Cluster) (corev1.CoreV1Interface, error) {
+	kubeconfig, err := kcfg.FromSecret(c, cluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %q in namespace %q",
+			cluster.Name, cluster.Namespace)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client configuration for Cluster %q in namespace %q",
+			cluster.Name, cluster.Namespace)
+	}
+
+	return corev1.NewForConfig(restConfig)
+}

--- a/baremetal/remote/remote_test.go
+++ b/baremetal/remote/remote_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	clusterWithValidKubeConfig = &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test1",
+			Namespace: "test",
+		},
+	}
+
+	clusterWithInvalidKubeConfig = &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test2-invalid",
+			Namespace: "test",
+		},
+	}
+
+	clusterWithNoKubeConfig = &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test3",
+			Namespace: "test",
+		},
+	}
+
+	validKubeConfig = `
+clusters:
+- cluster:
+    server: https://test-cluster-api:6443
+  name: test-cluster-api
+contexts:
+- context:
+    cluster: test-cluster-api
+    user: kubernetes-admin
+  name: kubernetes-admin@test-cluster-api
+current-context: kubernetes-admin@test-cluster-api
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+`
+
+	validSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test1-kubeconfig",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			secret.KubeconfigDataName: []byte(validKubeConfig),
+		},
+	}
+
+	invalidSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test2-invalid-kubeconfig",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			secret.KubeconfigDataName: []byte("Not valid!!1"),
+		},
+	}
+)
+
+func TestNewClusterClient(t *testing.T) {
+	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
+		client := fake.NewFakeClient(validSecret)
+		c, err := NewClusterClient(client, clusterWithValidKubeConfig)
+		if err != nil {
+			t.Fatalf("Expected no errors, got %v", err)
+		}
+
+		if c == nil {
+			t.Fatal("Expected actual client, got nil")
+		}
+	})
+
+	t.Run("cluster with no kubeconfig", func(t *testing.T) {
+		client := fake.NewFakeClient()
+		_, err := NewClusterClient(client, clusterWithNoKubeConfig)
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("Expected not found error, got %v", err)
+		}
+	})
+
+	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
+		client := fake.NewFakeClient(invalidSecret)
+		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig)
+		if err == nil || apierrors.IsNotFound(err) {
+			t.Fatalf("Expected error, got %v", err)
+		}
+	})
+
+}

--- a/baremetal/remote/remote_test.go
+++ b/baremetal/remote/remote_test.go
@@ -110,7 +110,7 @@ func TestNewClusterClient(t *testing.T) {
 		client := fake.NewFakeClient(invalidSecret)
 		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig)
 		if err == nil || apierrors.IsNotFound(err) {
-			t.Fatalf("Expected error, got %v", err)
+			t.Fatalf("Expected error other than not found, got %v", err)
 		}
 	})
 

--- a/controllers/baremetalcluster_controller_test.go
+++ b/controllers/baremetalcluster_controller_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 		Entry("Should not return an error when baremetalcluster is not found",
 			TestCaseReconcileBMC{
 				Objects: []runtime.Object{
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 				},
 				ErrorExpected:   false,
 				RequeueExpected: false,
@@ -112,7 +112,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 			TestCaseReconcileBMC{
 				Objects: []runtime.Object{
 					newBareMetalCluster(baremetalClusterName, nil, nil, nil),
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 				},
 				ErrorExpected:   false,
 				RequeueExpected: false,
@@ -123,7 +123,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 			TestCaseReconcileBMC{
 				Objects: []runtime.Object{
 					newBareMetalCluster(baremetalClusterName, bmcOwnerRef, nil, nil),
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 				},
 				ErrorExpected:       true,
 				ErrorType:           &infrav1.APIEndPointError{},
@@ -137,7 +137,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 			TestCaseReconcileBMC{
 				Objects: []runtime.Object{
 					newBareMetalCluster(baremetalClusterName, bmcOwnerRef, bmcSpec, nil),
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 				},
 				ErrorExpected:   false,
 				RequeueExpected: false,
@@ -159,7 +159,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 						},
 						Spec: *bmcSpec,
 					},
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 				},
 				ErrorExpected:   false,
 				RequeueExpected: false,
@@ -181,7 +181,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 						},
 						Spec: *bmcSpec,
 					},
-					newCluster(clusterName),
+					newCluster(clusterName, nil, nil),
 					newMachine(clusterName, machineName, ""),
 				},
 				ErrorExpected:   false,

--- a/go.mod
+++ b/go.mod
@@ -3,25 +3,16 @@ module sigs.k8s.io/cluster-api-provider-baremetal
 go 1.13
 
 require (
-	github.com/coreos/etcd v3.3.15+incompatible // indirect
-	github.com/coreos/go-oidc v2.1.0+incompatible // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/go-openapi/validate v0.19.2 // indirect
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
-	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/metal3-io/baremetal-operator v0.0.0-20191004200613-f048f3bc5f05
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
-	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/spf13/cobra v0.0.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
@@ -31,17 +22,11 @@ require (
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	golang.org/x/tools v0.0.0-20191017101817-846f856e7d71 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
-	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 // indirect
-	google.golang.org/grpc v1.23.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/square/go-jose.v2 v2.2.2 // indirect
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-	k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269 // indirect
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a
 	sigs.k8s.io/cluster-api v0.2.7
 	sigs.k8s.io/controller-runtime v0.3.1-0.20191029211253-40070e2a1958
-	sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca // indirect
 )

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/klogr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-baremetal/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-provider-baremetal/baremetal"
+	capbmremote "sigs.k8s.io/cluster-api-provider-baremetal/baremetal/remote"
 	"sigs.k8s.io/cluster-api-provider-baremetal/controllers"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -88,9 +89,10 @@ func main() {
 	}
 
 	if err := (&controllers.BareMetalMachineReconciler{
-		Client:         mgr.GetClient(),
-		ManagerFactory: baremetal.NewManagerFactory(mgr.GetClient()),
-		Log:            ctrl.Log.WithName("controllers").WithName("BareMetalMachine"),
+		Client:           mgr.GetClient(),
+		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
+		Log:              ctrl.Log.WithName("controllers").WithName("BareMetalMachine"),
+		CapiClientGetter: capbmremote.NewClusterClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BareMetalMachineReconciler")
 		os.Exit(1)


### PR DESCRIPTION
When no cloud provider is deployed, set the providerID by
directly interacting with the target cluster api.