### PR TITLE
Improve assertions in BM Machine Contoller test

### DIFF
--- a/controllers/baremetalcluster_controller_test.go
+++ b/controllers/baremetalcluster_controller_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/klogr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-baremetal/api/v1alpha2"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -65,10 +64,6 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 
 			res, err := r.Reconcile(req)
 
-			key := client.ObjectKey{
-				Name:      baremetalClusterName,
-				Namespace: namespaceName,
-			}
 			if tc.ErrorExpected {
 				Expect(err).To(HaveOccurred())
 				if tc.ErrorType != nil {
@@ -85,7 +80,7 @@ var _ = Describe("Reconcile Baremetalcluster", func() {
 				Expect(res.Requeue).To(BeFalse())
 			}
 			if tc.ErrorReasonExpected {
-				_ = c.Get(context.TODO(), key, testclstr)
+				_ = c.Get(context.TODO(), *getKey(baremetalClusterName), testclstr)
 				Expect(testclstr.Status.ErrorReason).NotTo(BeNil())
 				Expect(tc.ErrorReason).To(Equal(*testclstr.Status.ErrorReason))
 			}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -145,6 +145,13 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
+func getKey(objectName string) *client.ObjectKey {
+	return &client.ObjectKey{
+		Name:      objectName,
+		Namespace: namespaceName,
+	}
+}
+
 func newCluster(clusterName string) *clusterv1.Cluster {
 	return &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,7 @@ k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BF
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apimachinery v0.0.0-20191121015412-41065c7a8c2a h1:9V03T5lHv/iF4fSgvMCd+iB86AgEgmzLpheMqIJy7hs=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53q3Uz5OSfgsv4uxpScmmyYOOlk=


### PR DESCRIPTION
This PR improves the assertions in BM Machine Controller tests by checking associated objects' spec and/or status.
* Fixes minor bugs in testcases
* Adds a test case 
* Minor refactoring of BM Cluster Controller test.