### PR TITLE
Parameterize setting error reason on Machine and Cluster

### DIFF
--- a/baremetal/cluster_manager.go
+++ b/baremetal/cluster_manager.go
@@ -86,7 +86,7 @@ func (s *ClusterManager) Create(ctx context.Context) error {
 	err := config.IsValid()
 	if err != nil {
 		// Should have been picked earlier. Do not requeue
-		s.setError(ctx, err.Error())
+		s.setError(ctx, err.Error(), capierrors.InvalidConfigurationClusterError)
 		return err
 	}
 
@@ -160,9 +160,8 @@ func (s *ClusterManager) UpdateClusterStatus() error {
 // setError sets the ErrorMessage and ErrorReason fields on the machine and logs
 // the message. It assumes the reason is invalid configuration, since that is
 // currently the only relevant MachineStatusError choice.
-func (s *ClusterManager) setError(ctx context.Context, message string) {
+func (s *ClusterManager) setError(ctx context.Context, message string, reason capierrors.ClusterStatusError) {
 	s.BareMetalCluster.Status.ErrorMessage = &message
-	reason := capierrors.InvalidConfigurationClusterError
 	s.BareMetalCluster.Status.ErrorReason = &reason
 }
 

--- a/baremetal/machine_manager.go
+++ b/baremetal/machine_manager.go
@@ -174,7 +174,7 @@ func (m *MachineManager) Associate(ctx context.Context) error {
 	err := config.IsValid()
 	if err != nil {
 		// Should have been picked earlier. Do not requeue
-		m.setError(ctx, err.Error())
+		m.setError(ctx, err.Error(), capierrors.InvalidConfigurationMachineError)
 		return nil
 	}
 
@@ -604,9 +604,8 @@ func (m *MachineManager) HasAnnotation() bool {
 // setError sets the ErrorMessage and ErrorReason fields on the machine and logs
 // the message. It assumes the reason is invalid configuration, since that is
 // currently the only relevant MachineStatusError choice.
-func (m *MachineManager) setError(ctx context.Context, message string) {
+func (m *MachineManager) setError(ctx context.Context, message string, reason capierrors.MachineStatusError) {
 	m.BareMetalMachine.Status.ErrorMessage = &message
-	reason := capierrors.InvalidConfigurationMachineError
 	m.BareMetalMachine.Status.ErrorReason = &reason
 }
 


### PR DESCRIPTION
Currently, only a single error reason is hard coded. 
The caller need to provide both error message and error status.