### PR TITLE
fixes stuck deletion when host has no Status

### DIFF
--- a/pkg/cloud/baremetal/actuators/machine/actuator.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator.go
@@ -165,7 +165,7 @@ func (a *Actuator) Delete(ctx context.Context, cluster *machinev1.Cluster, machi
 		switch host.Status.Provisioning.State {
 		case bmh.StateRegistrationError, bmh.StateRegistering,
 			bmh.StateMatchProfile, bmh.StateInspecting,
-			bmh.StateReady, bmh.StateValidationError:
+			bmh.StateReady, bmh.StateValidationError, bmh.StateNone:
 			// Host is not provisioned
 			waiting = false
 		case bmh.StateExternallyProvisioned:

--- a/pkg/cloud/baremetal/actuators/machine/actuator_test.go
+++ b/pkg/cloud/baremetal/actuators/machine/actuator_test.go
@@ -808,6 +808,38 @@ func TestDelete(t *testing.T) {
 			ExpectedResult: &clustererror.RequeueAfterError{},
 		},
 		{
+			CaseName: "deprovisioning not required, no host status",
+			Host: &bmh.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myhost",
+					Namespace: "myns",
+				},
+				Spec: bmh.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name:       "mymachine",
+						Namespace:  "myns",
+						Kind:       "Machine",
+						APIVersion: machinev1.SchemeGroupVersion.String(),
+					},
+				},
+			},
+			Machine: machinev1.Machine{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Machine",
+					APIVersion: machinev1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mymachine",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						HostAnnotation: "myns/myhost",
+					},
+				},
+			},
+			ExpectedConsumerRef: nil,
+			ExpectedResult:      nil,
+		},
+		{
 			CaseName: "deprovisioning in progress",
 			Host: &bmh.BareMetalHost{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1466,7 +1498,7 @@ func TestNodeAddresses(t *testing.T) {
 		},
 		{
 			// no host at all, so this is a no-op
-			Host:                  nil,
+			Host: nil,
 			ExpectedNodeAddresses: nil,
 		},
 	}


### PR DESCRIPTION
If a Machine is being deleted and is associated with a BareMetalHost that has
no status, the deletion logic would fail to identify that the host is
unprovisioned. It would requeue forever, waiting for the host to reach an
unprovisioned state.

This can happen if there are BareMetalHosts without a running
baremetal-operator, and Machines with this provider running.