### PR TITLE
[V1alpha2] Handle properly bmh state none while deleting baremetal machine

### DIFF
--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -339,7 +339,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		// TODO? remove empty string that is the status without BMO running
 		case bmh.StateRegistrationError, bmh.StateRegistering,
 			bmh.StateMatchProfile, bmh.StateInspecting,
-			bmh.StateReady, bmh.StateValidationError, "":
+			bmh.StateReady, bmh.StateValidationError, bmh.StateNone:
 			// Host is not provisioned
 			waiting = false
 		case bmh.StateExternallyProvisioned:

--- a/baremetal/baremetalmachine_manager_test.go
+++ b/baremetal/baremetalmachine_manager_test.go
@@ -1066,6 +1066,18 @@ func TestDelete(t *testing.T) {
 			ExpectedConsumerRef: consumerRef,
 			ExpectedResult:      &RequeueAfterError{},
 		},
+		"No Host status, deprovisioning needed": {
+			Host:                newBareMetalHost("myhost", bmhSpec, bmh.StateNone, nil, false),
+			Machine:             newMachine("mymachine", "", nil),
+			BMMachine:           newBareMetalMachine("mybmmachine", nil, nil, nil, bmmObjectMetaWithValidAnnotations),
+			ExpectedConsumerRef: consumerRef,
+			ExpectedResult:      &RequeueAfterError{},
+		},
+		"No Host status, no deprovisioning needed": {
+			Host:      newBareMetalHost("myhost", bmhSpecNoImg, bmh.StateNone, nil, false),
+			Machine:   newMachine("mymachine", "", nil),
+			BMMachine: newBareMetalMachine("mybmmachine", nil, nil, nil, bmmObjectMetaWithValidAnnotations),
+		},
 		"Deprovisioning in progress": {
 			Host:                newBareMetalHost("myhost", bmhSpecNoImg, bmh.StateDeprovisioning, bmhStatus, false),
 			Machine:             newMachine("mymachine", "", nil),


### PR DESCRIPTION
A host without status would block the deletion of the baremetal
machine, as it would default to waiting in the Delete function.
Now considering a host without status as deprovisioned during
the deletion of the baremetal machine

Similar to #195 for v1alpha2