### PR TITLE
adds auto-scaling for MachineSet based on number of BareMetalHosts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1010,6 +1010,7 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "golang.org/x/net/context",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ For more information about this actuator and related repositories, see
 
 See the [API Documentation](docs/api.md) for details about the `providerSpec`
 API used with this `cluster-api` provider.
+
+## MachineSet Scaling
+
+If you would like a MachineSet to be automatically scaled to the number of
+matching BareMetalHosts, annotate that MachineSet with key
+`metal3.io/autoscale-to-hosts` and any value.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/controller"
 	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/manager/wrapper"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -96,6 +97,11 @@ func main() {
 
 	// the manager wrapper will add an extra Watch to the controller
 	capimachine.AddWithActuator(wrapper.New(mgr), machineActuator)
+
+	if err := controller.AddToManager(mgr); err != nil {
+		log.Error(err, "Failed to add controller to manager")
+		os.Exit(1)
+	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		entryLog.Error(err, "unable to run manager")

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -49,18 +49,15 @@ rules:
   - update
   - patch
 - apiGroups:
-  - baremetal.cluster.k8s.io
+  - cluster.k8s.io
   resources:
-  - baremetalmachineproviderspecs
-  - baremetalmachineproviderstatuses
+  - machinesets
   verbs:
   - get
   - list
   - watch
-  - create
   - update
   - patch
-  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/hack/othercrds/cluster_v1alpha1_cluster.yaml
+++ b/hack/othercrds/cluster_v1alpha1_cluster.yaml
@@ -1,0 +1,98 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusters.cluster.k8s.io
+spec:
+  group: cluster.k8s.io
+  names:
+    kind: Cluster
+    plural: clusters
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterNetwork:
+              properties:
+                pods:
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+                serviceDomain:
+                  type: string
+                services:
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+              required:
+              - services
+              - pods
+              - serviceDomain
+              type: object
+            providerSpec:
+              properties:
+                value:
+                  type: object
+                valueFrom:
+                  properties:
+                    machineClass:
+                      properties:
+                        provider:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          required:
+          - clusterNetwork
+          type: object
+        status:
+          properties:
+            apiEndpoints:
+              items:
+                properties:
+                  host:
+                    type: string
+                  port:
+                    format: int64
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              type: array
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            providerStatus:
+              type: object
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/hack/othercrds/cluster_v1alpha1_machine.yaml
+++ b/hack/othercrds/cluster_v1alpha1_machine.yaml
@@ -1,0 +1,111 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machines.cluster.k8s.io
+spec:
+  group: cluster.k8s.io
+  names:
+    kind: Machine
+    plural: machines
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            configSource:
+              type: object
+            metadata:
+              type: object
+            providerSpec:
+              properties:
+                value:
+                  type: object
+                valueFrom:
+                  properties:
+                    machineClass:
+                      properties:
+                        provider:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            taints:
+              items:
+                type: object
+              type: array
+            versions:
+              properties:
+                controlPlane:
+                  type: string
+                kubelet:
+                  type: string
+              required:
+              - kubelet
+              type: object
+          required:
+          - providerSpec
+          type: object
+        status:
+          properties:
+            addresses:
+              items:
+                type: object
+              type: array
+            conditions:
+              items:
+                type: object
+              type: array
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            lastOperation:
+              properties:
+                description:
+                  type: string
+                lastUpdated:
+                  format: date-time
+                  type: string
+                state:
+                  type: string
+                type:
+                  type: string
+              type: object
+            lastUpdated:
+              format: date-time
+              type: string
+            nodeRef:
+              type: object
+            phase:
+              type: string
+            providerStatus:
+              type: object
+            versions:
+              properties:
+                controlPlane:
+                  type: string
+                kubelet:
+                  type: string
+              required:
+              - kubelet
+              type: object
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/hack/othercrds/cluster_v1alpha1_machineset.yaml
+++ b/hack/othercrds/cluster_v1alpha1_machineset.yaml
@@ -1,0 +1,227 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: machinesets.cluster.k8s.io
+spec:
+  group: cluster.k8s.io
+  names:
+    kind: MachineSet
+    plural: machinesets
+    shortNames:
+    - ms
+  scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.labelSelector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            deletePolicy:
+              description: DeletePolicy defines the policy used to identify nodes
+                to delete when downscaling. Defaults to "Random".  Valid values are
+                "Random, "Newest", "Oldest"
+              enum:
+              - Random
+              - Newest
+              - Oldest
+              type: string
+            minReadySeconds:
+              description: MinReadySeconds is the minimum number of seconds for which
+                a newly created machine should be ready. Defaults to 0 (machine will
+                be considered available as soon as it is ready)
+              format: int32
+              type: integer
+            replicas:
+              description: Replicas is the number of desired replicas. This is a pointer
+                to distinguish between explicit zero and unspecified. Defaults to
+                1.
+              format: int32
+              type: integer
+            selector:
+              description: 'Selector is a label query over machines that should match
+                the replica count. Label keys and values that must match in order
+                to be controlled by this MachineSet. It must match the machine template''s
+                labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              type: object
+            template:
+              description: Template is the object that describes the machine that
+                will be created if insufficient replicas are detected.
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  type: object
+                spec:
+                  description: 'Specification of the desired behavior of the machine.
+                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                  properties:
+                    configSource:
+                      description: ConfigSource is used to populate in the associated
+                        Node for dynamic kubelet config. This field already exists
+                        in Node, so any updates to it in the Machine spec will be
+                        automatically copied to the linked NodeRef from the status.
+                        The rest of dynamic kubelet config support should then work
+                        as-is.
+                      type: object
+                    metadata:
+                      description: ObjectMeta will autopopulate the Node created.
+                        Use this to indicate what labels, annotations, name prefix,
+                        etc., should be used when creating the Node.
+                      type: object
+                    providerID:
+                      description: ProviderID is the identification ID of the machine
+                        provided by the provider. This field must match the provider
+                        ID as seen on the node object corresponding to this machine.
+                        This field is required by higher level consumers of cluster-api.
+                        Example use case is cluster autoscaler with cluster-api as
+                        provider. Clean-up logic in the autoscaler compares machines
+                        to nodes to find out machines at provider which could not
+                        get registered as Kubernetes nodes. With cluster-api as a
+                        generic out-of-tree provider for autoscaler, this field is
+                        required by autoscaler to be able to have a provider view
+                        of the list of machines. Another list of nodes is queried
+                        from the k8s apiserver and then a comparison is done to find
+                        out unregistered machines and are marked for delete. This
+                        field will be set by the actuators and consumed by higher
+                        level entities like autoscaler that will be interfacing with
+                        cluster-api as generic provider.
+                      type: string
+                    providerSpec:
+                      description: ProviderSpec details Provider-specific configuration
+                        to use during node creation.
+                      properties:
+                        value:
+                          description: Value is an inlined, serialized representation
+                            of the resource configuration. It is recommended that
+                            providers maintain their own versioned API types that
+                            should be serialized/deserialized from this field, akin
+                            to component config.
+                          type: object
+                        valueFrom:
+                          description: Source for the provider configuration. Cannot
+                            be used if value is not empty.
+                          properties:
+                            machineClass:
+                              description: The machine class from which the provider
+                                config should be sourced.
+                              properties:
+                                provider:
+                                  description: Provider is the name of the cloud-provider
+                                    which MachineClass is intended for.
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    taints:
+                      description: The list of the taints to be applied to the corresponding
+                        Node in additive manner. This list will not overwrite any
+                        other taints added to the Node on an ongoing basis by other
+                        entities. These taints should be actively reconciled e.g.
+                        if you ask the machine controller to apply a taint and then
+                        manually remove the taint the machine controller will put
+                        it back) but not have the machine controller remove any taints
+                      items:
+                        type: object
+                      type: array
+                    versions:
+                      description: Versions of key software to use. This field is
+                        optional at cluster creation time, and omitting the field
+                        indicates that the cluster installation tool should select
+                        defaults for the user. These defaults may differ based on
+                        the cluster installer, but the tool should populate the values
+                        it uses when persisting Machine objects. A Machine spec missing
+                        this field at runtime is invalid.
+                      properties:
+                        controlPlane:
+                          description: ControlPlane is the semantic version of the
+                            Kubernetes control plane to run. This should only be populated
+                            when the machine is a control plane.
+                          type: string
+                        kubelet:
+                          description: Kubelet is the semantic version of kubelet
+                            to run
+                          type: string
+                      required:
+                      - kubelet
+                      type: object
+                  required:
+                  - providerSpec
+                  type: object
+              type: object
+          required:
+          - selector
+          type: object
+        status:
+          properties:
+            availableReplicas:
+              description: The number of available replicas (ready for at least minReadySeconds)
+                for this MachineSet.
+              format: int32
+              type: integer
+            errorMessage:
+              type: string
+            errorReason:
+              description: In the event that there is a terminal problem reconciling
+                the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason
+                will be populated with a succinct value suitable for machine interpretation,
+                while ErrorMessage will contain a more verbose string suitable for
+                logging and human consumption.  These fields should not be set for
+                transitive errors that a controller faces that are expected to be
+                fixed automatically over time (like service outages), but instead
+                indicate that something is fundamentally wrong with the MachineTemplate's
+                spec or the configuration of the machine controller, and that manual
+                intervention is required. Examples of terminal errors would be invalid
+                combinations of settings in the spec, values that are unsupported
+                by the machine controller, or the responsible machine controller itself
+                being critically misconfigured.  Any transient errors that occur during
+                the reconciliation of Machines can be added as events to the MachineSet
+                object and/or logged in the controller's output.
+              type: string
+            fullyLabeledReplicas:
+              description: The number of replicas that have labels matching the labels
+                of the machine template of the MachineSet.
+              format: int32
+              type: integer
+            observedGeneration:
+              description: ObservedGeneration reflects the generation of the most
+                recently observed MachineSet.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: The number of ready replicas for this MachineSet. A machine
+                is considered ready when the node has been created and is "Ready".
+              format: int32
+              type: integer
+            replicas:
+              description: Replicas is the most recently observed number of replicas.
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/hack/othercrds/metal3_v1alpha1_baremetalhost_crd.yaml
+++ b/hack/othercrds/metal3_v1alpha1_baremetalhost_crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: baremetalhosts.metal3.io
+spec:
+  group: metal3.io
+  names:
+    kind: BareMetalHost
+    listKind: BareMetalHostList
+    plural: baremetalhosts
+    singular: baremetalhost
+  scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}

--- a/pkg/controller/add_machineset.go
+++ b/pkg/controller/add_machineset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,15 +17,10 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
-	capimachine "sigs.k8s.io/cluster-api/pkg/controller/machine"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/controller/machineset"
 )
 
-//+kubebuilder:rbac:groups=baremetal.cluster.k8s.io,resources=baremetalmachineproviderspecs;baremetalmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {
-		return capimachine.AddWithActuator(m, &machine.Actuator{})
-	})
+	AddToManagerFuncs = append(AddToManagerFuncs, machineset.Add)
 }

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"context"
+
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	actuator "github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	machinev1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("machineset-controller")
+
+// Add creates a new MachineSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileMachineSet{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("machineset-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to MachineSet
+	err = c.Watch(&source.Kind{Type: &machinev1alpha1.MachineSet{}},
+		&handler.EnqueueRequestForObject{}, predicate.ResourceVersionChangedPredicate{})
+	if err != nil {
+		return err
+	}
+
+	mapper := msmapper{client: mgr.GetClient()}
+	err = c.Watch(&source.Kind{Type: &bmh.BareMetalHost{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper}, predicate.ResourceVersionChangedPredicate{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileMachineSet{}
+
+// ReconcileMachineSet reconciles a MachineSet object
+type ReconcileMachineSet struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a MachineSet object and makes changes based on the state read
+// and what is in the MachineSet.Spec
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinesets,verbs=get;list;watch;update;patch
+func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log := log.WithValues("MachineSet", request.NamespacedName.String())
+	ctx := context.TODO()
+	// Fetch the MachineSet instance
+	instance := &machinev1alpha1.MachineSet{}
+	err := r.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Don't take action if the annotation is not present
+	annotations := instance.ObjectMeta.GetAnnotations()
+	if annotations == nil {
+		return reconcile.Result{}, nil
+	}
+	_, present := annotations[AutoScaleAnnotation]
+	if !present {
+		return reconcile.Result{}, nil
+	}
+
+	selector, err := actuator.SelectorFromProviderSpec(&instance.Spec.Template.Spec.ProviderSpec)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// The HostSelector limits which BareMetalHosts can be matched with a
+	// Machine. If you have a MachineSet in your cluster that matches *anything*
+	// because it lacks a HostSelector, then if you try to add a second
+	// MachineSet later that does have a HostSelector, the first MachineSet will
+	// compete with it for the same BareMetalHosts.
+	if selector.Empty() {
+		log.Info("MachineSet lacks a HostSelector; adding a future MachineSet may be difficult.")
+	}
+
+	hosts := &bmh.BareMetalHostList{}
+	opts := &client.ListOptions{
+		Namespace: instance.Namespace,
+	}
+
+	err = r.List(ctx, opts, hosts)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	var count int32
+	for _, host := range hosts.Items {
+		if selector.Matches(labels.Set(host.ObjectMeta.Labels)) {
+			count++
+		}
+	}
+
+	if instance.Spec.Replicas == nil || count != *instance.Spec.Replicas {
+		log.Info("Scaling MachineSet", "new_replicas", count, "old_replicas", instance.Spec.Replicas)
+		new := instance.DeepCopy()
+		new.Spec.Replicas = &count
+		err = r.Update(ctx, new)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/machineset/machineset_controller_suite_test.go
+++ b/pkg/controller/machineset/machineset_controller_suite_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	bmoapis "github.com/metal3-io/baremetal-operator/pkg/apis"
+	"github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clusterapis "sigs.k8s.io/cluster-api/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var cfg *rest.Config
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crds"),
+			filepath.Join("..", "..", "..", "hack", "othercrds"),
+		},
+	}
+	apis.AddToScheme(scheme.Scheme)
+	clusterapis.AddToScheme(scheme.Scheme)
+	bmoapis.AddToScheme(scheme.Scheme)
+
+	var err error
+	if cfg, err = t.Start(); err != nil {
+		stdlog.Fatal(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
+
+// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
+// writes the request to requests after Reconcile is finished.
+func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
+	requests := make(chan reconcile.Request)
+	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
+		result, err := inner.Reconcile(req)
+		requests <- req
+		return result, err
+	})
+	return fn, requests
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}, *sync.WaitGroup) {
+	stop := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
+	}()
+	return stop, wg
+}

--- a/pkg/controller/machineset/machineset_controller_test.go
+++ b/pkg/controller/machineset/machineset_controller_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	bmv1alpha1 "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
+	"github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	machinev1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var c client.Client
+
+var expectedRequest1 = reconcile.Request{NamespacedName: types.NamespacedName{Name: "machineset1", Namespace: "default"}}
+var expectedRequest2 = reconcile.Request{NamespacedName: types.NamespacedName{Name: "machineset2", Namespace: "default"}}
+var machinesetKey1 = types.NamespacedName{Name: "machineset1", Namespace: "default"}
+var machinesetKey2 = types.NamespacedName{Name: "machineset2", Namespace: "default"}
+
+const timeout = time.Second * 10
+
+func TestScale(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	rawProviderSpec, err := json.Marshal(&bmv1alpha1.BareMetalMachineProviderSpec{
+		HostSelector: bmv1alpha1.HostSelector{
+			MatchLabels: map[string]string{"size": "large"},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	instance := &machinev1alpha1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "machineset1",
+			Namespace:   "default",
+			Annotations: map[string]string{AutoScaleAnnotation: "yesplease"},
+		},
+		Spec: machinev1alpha1.MachineSetSpec{
+			Template: machinev1alpha1.MachineTemplateSpec{
+				Spec: machinev1alpha1.MachineSpec{
+					ProviderSpec: machinev1alpha1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProviderSpec},
+					},
+				},
+			},
+		},
+	}
+	host1 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host1",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "large"},
+		},
+	}
+	host2 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host2",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "large"},
+		},
+	}
+	// This host has a different label, so it should not match
+	host3 := bmh.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host3",
+			Namespace: "default",
+			Labels:    map[string]string{"size": "extramedium"},
+		},
+	}
+
+	// Setup the Manager and Controller. Wrap the Controller Reconcile function
+	// so it writes each request to a channel when it is finished.
+	mgr, err := manager.New(cfg, manager.Options{Scheme: scheme.Scheme})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c = mgr.GetClient()
+
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	g.Expect(add(mgr, recFn)).To(gomega.Succeed())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	// Create BareMetalHosts
+	hosts := []runtime.Object{&host1, &host2, &host3}
+	for i := range hosts {
+		err = c.Create(context.TODO(), hosts[i])
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		defer c.Delete(context.TODO(), hosts[i])
+	}
+
+	// Create the MachineSet object and expect the Reconcile to happen
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), instance)
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest1)))
+
+	g.Eventually(func() error {
+		ms := machinev1alpha1.MachineSet{}
+		err := c.Get(context.TODO(), machinesetKey1, &ms)
+		if err != nil {
+			return err
+		}
+		if ms.Spec.Replicas == nil || *ms.Spec.Replicas != 2 {
+			return fmt.Errorf("Replicas is not 2")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+
+	// Delete a host and expect the MachineSet to be scaled down
+	g.Expect(c.Delete(context.TODO(), &host1)).To(gomega.Succeed())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest1)))
+
+	g.Eventually(func() error {
+		ms := machinev1alpha1.MachineSet{}
+		err := c.Get(context.TODO(), machinesetKey1, &ms)
+		if err != nil {
+			return err
+		}
+		if ms.Spec.Replicas == nil || *ms.Spec.Replicas != 1 {
+			return fmt.Errorf("Replicas is not 1")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+}
+
+// TestIgnore ensures that a MachineSet without the annotation gets ignored.
+func TestIgnore(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	rawProviderSpec, err := json.Marshal(&bmv1alpha1.BareMetalMachineProviderSpec{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	five := int32(5)
+	instance := &machinev1alpha1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machineset2",
+			Namespace: "default",
+		},
+		Spec: machinev1alpha1.MachineSetSpec{
+			Replicas: &five,
+			Template: machinev1alpha1.MachineTemplateSpec{
+				Spec: machinev1alpha1.MachineSpec{
+					ProviderSpec: machinev1alpha1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawProviderSpec},
+					},
+				},
+			},
+		},
+	}
+
+	// Setup the Manager and Controller. Wrap the Controller Reconcile function
+	// so it writes each request to a channel when it is finished.
+	mgr, err := manager.New(cfg, manager.Options{Scheme: scheme.Scheme})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c = mgr.GetClient()
+
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	g.Expect(add(mgr, recFn)).To(gomega.Succeed())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	// Create the MachineSet object and expect the Reconcile to happen
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), instance)
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest2)))
+
+	g.Eventually(func() error {
+		ms := machinev1alpha1.MachineSet{}
+		err := c.Get(context.TODO(), machinesetKey2, &ms)
+		if err != nil {
+			return err
+		}
+		if *ms.Spec.Replicas != 5 {
+			return fmt.Errorf("replicas is not 5; the MachineSet was not ignored as expected")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+}

--- a/pkg/controller/machineset/mapper.go
+++ b/pkg/controller/machineset/mapper.go
@@ -1,0 +1,72 @@
+package machineset
+
+import (
+	"context"
+	"fmt"
+
+	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+	actuator "github.com/metal3-io/cluster-api-provider-baremetal/pkg/cloud/baremetal/actuators/machine"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	machinev1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AutoScaleAnnotation is an annotation key that, when added to a MachineSet
+// with any value, indicates that this controller should scale that MachineSet
+// to equal the number of matching BareMetalHosts in the same namespace.
+const AutoScaleAnnotation = "metal3.io/autoscale-to-hosts"
+
+type msmapper struct {
+	client client.Client
+}
+
+// Map will return reconcile requests for a MachineSet if the event is for a
+// BareMetalHost and that BareMetalHost matches the MachineSet's HostSelector.
+func (m *msmapper) Map(obj handler.MapObject) []reconcile.Request {
+	requests := []reconcile.Request{}
+	if host, ok := obj.Object.(*bmh.BareMetalHost); ok {
+		msets := machinev1alpha1.MachineSetList{}
+		err := m.client.List(context.TODO(), &client.ListOptions{Namespace: host.Namespace}, &msets)
+		if err != nil {
+			log.Error(err, "failed to list MachineSets")
+			return []reconcile.Request{}
+		}
+		for _, ms := range msets.Items {
+			annotations := ms.ObjectMeta.GetAnnotations()
+			if annotations == nil {
+				continue
+			}
+			_, present := annotations[AutoScaleAnnotation]
+			if !present {
+				continue
+			}
+
+			matches, err := m.hostMatchesMachineSet(host, &ms)
+			if err != nil {
+				nn := fmt.Sprintf("%s/%s", ms.Namespace, ms.Name)
+				log.Error(err, "failed to determine if host matches MachineSet", "MachineSet", nn)
+				continue
+			}
+			if matches {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      ms.Name,
+						Namespace: ms.Namespace,
+					},
+				})
+			}
+		}
+	}
+	return requests
+}
+
+func (m *msmapper) hostMatchesMachineSet(host *bmh.BareMetalHost, ms *machinev1alpha1.MachineSet) (bool, error) {
+	selector, err := actuator.SelectorFromProviderSpec(&ms.Spec.Template.Spec.ProviderSpec)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(labels.Set(host.ObjectMeta.Labels)), nil
+}


### PR DESCRIPTION
In many clusters, it is desirable for the size of a MachineSet to always equal
the number of matching BareMetalHosts. In such a scenario, the cluster owner
wants all of their hardware to be provisioned and turned into Nodes, and they
want to remove excess Machines in case they remove hosts from their cluster.
This change adds a controller that scales MachineSets to the number of matching
BareMetalHosts. The behavior is opt-in, requiring an annotation on the
MachineSet.

fixes #188