### PR TITLE
✨ Do not require generate-examples for Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ install:
 	kubectl apply -k config/crd
 
 #Deploy the BaremetalHost CRDs and CRs (for testing purposes only)
-deploy-bmo-cr: generate-examples
+deploy-bmo-cr:
 	kubectl apply -f ./examples/_out/metal3crds.yaml
 	kubectl apply -f ./examples/_out/metal3plane.yaml
 
@@ -281,12 +281,12 @@ deploy: generate-examples
 	kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment cert-manager-webhook
 	kubectl apply -f examples/_out/provider-components.yaml
 
-deploy-examples: generate-examples
+deploy-examples:
 	kubectl apply -f ./examples/_out/cluster.yaml
 	kubectl apply -f ./examples/_out/machinedeployment.yaml
 	kubectl apply -f ./examples/_out/controlplane.yaml
 
-delete-examples: generate-examples
+delete-examples:
 	kubectl delete -f ./examples/_out/controlplane.yaml
 	kubectl delete -f ./examples/_out/machinedeployment.yaml
 	kubectl delete -f ./examples/_out/cluster.yaml

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/metal3-io/cluster-api-provider-baremetal:master
+      - image: quay.io/metal3-io/cluster-api-provider-baremetal:v1alpha3
         name: manager


### PR DESCRIPTION
`make generate-examples` is now a dependency only for `make-deploy`. It needs to be run manually before `make deploy-bmo-cr` or if something is changed after deployment.

Also change temporarily the CAPBM image to use v1alpha3 tag.