### PR TITLE
🏃 Remove unneeded clusterName from external object CRDs

### DIFF
--- a/api/v1alpha3/baremetalcluster_types.go
+++ b/api/v1alpha3/baremetalcluster_types.go
@@ -34,10 +34,6 @@ type BareMetalClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
 	NoCloudProvider      bool        `json:"noCloudProvider,omitempty"`
-
-	// ClusterName is the name of the Cluster this object belongs to.
-	// +kubebuilder:validation:MinLength=1
-	ClusterName string `json:"clusterName"`
 }
 
 // IsValid returns an error if the object is not valid, otherwise nil. The

--- a/api/v1alpha3/baremetalmachine_types.go
+++ b/api/v1alpha3/baremetalmachine_types.go
@@ -49,10 +49,6 @@ type BareMetalMachineSpec struct {
 	// This is used to limit the set of BareMetalHost objects considered for
 	// claiming for a BaremetalMachine.
 	HostSelector HostSelector `json:"hostSelector,omitempty"`
-
-	// ClusterName is the name of the Cluster this object belongs to.
-	// +kubebuilder:validation:MinLength=1
-	ClusterName string `json:"clusterName"`
 }
 
 // IsValid returns an error if the object is not valid, otherwise nil. The

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalclusters.yaml
@@ -166,11 +166,6 @@ spec:
           spec:
             description: BareMetalClusterSpec defines the desired state of BareMetalCluster.
             properties:
-              clusterName:
-                description: ClusterName is the name of the Cluster this object belongs
-                  to.
-                minLength: 1
-                type: string
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.
@@ -188,7 +183,6 @@ spec:
               noCloudProvider:
                 type: boolean
             required:
-            - clusterName
             - controlPlaneEndpoint
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalmachines.yaml
@@ -235,11 +235,6 @@ spec:
           spec:
             description: BareMetalMachineSpec defines the desired state of BareMetalMachine
             properties:
-              clusterName:
-                description: ClusterName is the name of the Cluster this object belongs
-                  to.
-                minLength: 1
-                type: string
               hostSelector:
                 description: HostSelector specifies matching criteria for labels on
                   BareMetalHosts. This is used to limit the set of BareMetalHost objects
@@ -306,7 +301,6 @@ spec:
                     type: string
                 type: object
             required:
-            - clusterName
             - image
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_baremetalmachinetemplates.yaml
@@ -155,11 +155,6 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
-                      clusterName:
-                        description: ClusterName is the name of the Cluster this object
-                          belongs to.
-                        minLength: 1
-                        type: string
                       hostSelector:
                         description: HostSelector specifies matching criteria for
                           labels on BareMetalHosts. This is used to limit the set
@@ -228,7 +223,6 @@ spec:
                             type: string
                         type: object
                     required:
-                    - clusterName
                     - image
                     type: object
                 required:

--- a/examples/cluster/cluster.yaml
+++ b/examples/cluster/cluster.yaml
@@ -19,12 +19,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: BareMetalCluster
 metadata:
   name: ${CLUSTER_NAME}
-# spec:
-#   cloudName: ${CLUSTER_NAME}
-#   cloudsSecret:
-#     name: cloud-config
 spec:
-  clusterName: ${CLUSTER_NAME}
   controlPlaneEndpoint:
     host: 192.168.111.249
     port: 6443

--- a/examples/controlplane/controlplane.yaml
+++ b/examples/controlplane/controlplane.yaml
@@ -23,7 +23,6 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-0
 spec:
-  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"
@@ -71,7 +70,6 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-1
 spec:
-  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"
@@ -113,7 +111,6 @@ kind: BareMetalMachine
 metadata:
   name: ${CLUSTER_NAME}-controlplane-2
 spec:
-  clusterName: ${CLUSTER_NAME}
   image:
     url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
     checksum: "97830b21ed272a3d854615beb54cf004"

--- a/examples/machinedeployment/machinedeployment.yaml
+++ b/examples/machinedeployment/machinedeployment.yaml
@@ -40,7 +40,6 @@ spec:
       image:
         url: "http://172.22.0.1/images/rhcos-ootpa-latest.qcow2"
         checksum: "97830b21ed272a3d854615beb54cf004"
-      clusterName: ${CLUSTER_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
This was added unnecessarily to
BaremetalMachine, BaremetalCluster and BaremetalMachineTemplate