### PR TITLE
:Sparkles: Check Cluster.Spec.Pause and Pause Annotation in BMC & BMM reconcile

### DIFF
--- a/controllers/baremetalcluster_controller.go
+++ b/controllers/baremetalcluster_controller.go
@@ -97,6 +97,12 @@ func (r *BareMetalClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 		return ctrl.Result{}, nil
 	}
 
+	// Return early if BMCluster or Cluster is paused.
+	if util.IsPaused(cluster, baremetalCluster) {
+		clusterLog.Info("reconciliation is paused for this object")
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+	}
+
 	clusterLog = clusterLog.WithValues("cluster", cluster.Name)
 	clusterLog.Info("Reconciling BaremetalCluster")
 

--- a/controllers/baremetalmachine_controller.go
+++ b/controllers/baremetalmachine_controller.go
@@ -139,6 +139,12 @@ func (r *BareMetalMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 
 	machineLog = machineLog.WithValues("baremetal-cluster", baremetalCluster.Name)
 
+	// Return early if the BMMachine or Cluster is paused.
+	if util.IsPaused(cluster, capbmMachine) {
+		machineLog.Info("reconciliation is paused for this object")
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+	}
+
 	// Create a helper for managing the baremetal container hosting the machine.
 	machineMgr, err := r.ManagerFactory.NewMachineManager(cluster, baremetalCluster, capiMachine, capbmMachine, machineLog)
 	if err != nil {

--- a/controllers/baremetalmachine_controller_test.go
+++ b/controllers/baremetalmachine_controller_test.go
@@ -310,7 +310,7 @@ var _ = Describe("BareMetalMachine manager", func() {
 	// Legacy tests
 	It("TestBareMetalMachineReconciler_BareMetalClusterToBareMetalMachines", func() {
 		baremetalCluster := newBareMetalCluster("my-baremetal-cluster",
-			bmcOwnerRef(), bmcSpec(), nil,
+			bmcOwnerRef(), bmcSpec(), nil, false,
 		)
 		objects := []runtime.Object{
 			newCluster(clusterName, nil, nil),
@@ -342,7 +342,7 @@ var _ = Describe("BareMetalMachine manager", func() {
 
 	It("TestBareMetalMachineReconciler_BareMetalClusterToBareMetalMachines_with_no_cluster", func() {
 		baremetalCluster := newBareMetalCluster("my-baremetal-cluster",
-			bmcOwnerRef(), bmcSpec(), nil,
+			bmcOwnerRef(), bmcSpec(), nil, false,
 		)
 		objects := []runtime.Object{
 			baremetalCluster,


### PR DESCRIPTION
This PR checks Cluster.Spec.Pause and cluster.x-k8s.io/paused Annotation in BareMetalCluster & BareMetalMachine reconcile.

Tests are added.