### PR TITLE
🏃 Update go version to 1.13 for unit test docker image

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.12
+FROM registry.hub.docker.com/library/golang:1.13
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-baremetal:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-baremetal \
-    registry.hub.docker.com/library/golang:1.12 \
+    registry.hub.docker.com/library/golang:1.13 \
     /go/src/github.com/metal3-io/cluster-api-provider-baremetal/hack/govet.sh
 fi;


### PR DESCRIPTION
Required when adding the webhooks feature

/cc @kashifest 
/cc @fmuyassarov 