### PR TITLE
🏃 Refactor logging for controllers

### DIFF
--- a/controllers/baremetalcluster_controller.go
+++ b/controllers/baremetalcluster_controller.go
@@ -97,13 +97,14 @@ func (r *BareMetalClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 		return ctrl.Result{}, nil
 	}
 
+	clusterLog = clusterLog.WithValues("cluster", cluster.Name)
+
 	// Return early if BMCluster or Cluster is paused.
 	if util.IsPaused(cluster, baremetalCluster) {
 		clusterLog.Info("reconciliation is paused for this object")
 		return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}
 
-	clusterLog = clusterLog.WithValues("cluster", cluster.Name)
 	clusterLog.Info("Reconciling BaremetalCluster")
 
 	// Create a helper for managing a baremetal cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the cluster name in the logs before checking if the object is paused. That gives more information for debugging
