### PR TITLE
Add check for baremetal host available state

### DIFF
--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -388,7 +388,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		switch host.Status.Provisioning.State {
 		case bmh.StateRegistrationError, bmh.StateRegistering,
 			bmh.StateMatchProfile, bmh.StateInspecting,
-			bmh.StateReady, bmh.StateNone:
+			bmh.StateReady, bmh.StateAvailable,bmh.StateNone:
 			// Host is not provisioned
 			waiting = false
 		case bmh.StateExternallyProvisioned:

--- a/baremetal/baremetalmachine_manager_test.go
+++ b/baremetal/baremetalmachine_manager_test.go
@@ -1195,6 +1195,17 @@ var _ = Describe("BareMetalMachine manager", func() {
 			Secret:              newSecret(),
 			ExpectSecretDeleted: true,
 		}),
+		Entry("Consumer ref should be removed", testCaseDelete{
+			Host: newBareMetalHost("myhost", bmhSpecNoImg(), bmh.StateAvailable,
+				bmhStatus(), false, false,
+			),
+			Machine: newMachine("mymachine", "", nil),
+			BMMachine: newBareMetalMachine("mybmmachine", nil, bmmSecret(), nil,
+				bmmObjectMetaWithValidAnnotations(),
+			),
+			Secret:              newSecret(),
+			ExpectSecretDeleted: true,
+		}),
 		Entry("Consumer ref does not match, so it should not be removed",
 			testCaseDelete{
 				Host: newBareMetalHost("myhost", bmhSpecSomeImg(),

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 // indirect
-	github.com/metal3-io/baremetal-operator v0.0.0-20200207092945-ce276d44ddec
+	github.com/metal3-io/baremetal-operator v0.0.0-20200219190700-ab6db428b878
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,10 @@ github.com/metal3-io/baremetal-operator v0.0.0-20200116072141-3d7a06eb80b9 h1:mV
 github.com/metal3-io/baremetal-operator v0.0.0-20200116072141-3d7a06eb80b9/go.mod h1:o9ta8R2EEtSiQY53sXdoM50v5531G0oS+lC58Gcm+1Y=
 github.com/metal3-io/baremetal-operator v0.0.0-20200207092945-ce276d44ddec h1:cbGYTPHWO5ErkHIPCV9clnHixp43nzeOj8KEU9E2GXU=
 github.com/metal3-io/baremetal-operator v0.0.0-20200207092945-ce276d44ddec/go.mod h1:o9ta8R2EEtSiQY53sXdoM50v5531G0oS+lC58Gcm+1Y=
+github.com/metal3-io/baremetal-operator v0.0.0-20200218103159-f32e58b41c62 h1:zYAk2qlKkBj/ZTa9hq+TEayv0TNsjPABpoZfG0JKapU=
+github.com/metal3-io/baremetal-operator v0.0.0-20200218103159-f32e58b41c62/go.mod h1:o9ta8R2EEtSiQY53sXdoM50v5531G0oS+lC58Gcm+1Y=
+github.com/metal3-io/baremetal-operator v0.0.0-20200219190700-ab6db428b878 h1:8K8O0gQ0CxCu5af+QK8gohYRij5jiJjLyrS8XNVA2Ds=
+github.com/metal3-io/baremetal-operator v0.0.0-20200219190700-ab6db428b878/go.mod h1:o9ta8R2EEtSiQY53sXdoM50v5531G0oS+lC58Gcm+1Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
Follow up for BMO [PR 427 ](https://github.com/metal3-io/baremetal-operator/pull/427)
Required for the completion of BMO  [PR 340](https://github.com/metal3-io/baremetal-operator/pull/340)
In this PR, added StateAvialabel to  CAPBM  case statement
After this is merged, BMO  [PR 340](https://github.com/metal3-io/baremetal-operator/pull/340)  need to be merged and then clean up in CAPBM to remove StateReady 
Fixes [#315](https://github.com/metal3-io/baremetal-operator/issues/315)
