### PR TITLE
✨ Add OwnerReference and Finalizer on created userdata secret

### DIFF
--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -55,6 +55,7 @@ const (
 	requeueAfter       = time.Second * 30
 	bmRoleControlPlane = "control-plane"
 	bmRoleNode         = "node"
+	userDataFinalizer  = "baremetalmachine.infrastructure.cluster.x-k8s.io/userData"
 )
 
 // MachineManagerInterface is an interface for a ClusterManager
@@ -302,11 +303,12 @@ func (m *MachineManager) GetUserData(ctx context.Context) error {
 				metav1.OwnerReference{
 					Controller: pointer.BoolPtr(true),
 					APIVersion: m.BareMetalMachine.APIVersion,
-					Kind: m.BareMetalMachine.Kind,
-					Name: m.BareMetalMachine.Name,
-					UID: m.BareMetalMachine.UID,
+					Kind:       m.BareMetalMachine.Kind,
+					Name:       m.BareMetalMachine.Name,
+					UID:        m.BareMetalMachine.UID,
 				},
 			},
+			Finalizers: []string{userDataFinalizer},
 		},
 		Data: map[string][]byte{
 			"userData": decodedUserDataBytes,
@@ -437,6 +439,16 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 		)
 		return err
 	} else if err == nil {
+		//unset the finalizers (remove all since we do not expect anything else
+		// to control that object)
+		tmpBootstrapSecret.Finalizers = []string{}
+		err = m.client.Update(ctx, &tmpBootstrapSecret)
+		if err != nil {
+			m.setError("Failed to delete BareMetalMachine",
+				capierrors.DeleteMachineError,
+			)
+			return err
+		}
 		// Delete the secret with use data
 		err = m.client.Delete(ctx, &tmpBootstrapSecret)
 		if err != nil {

--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -298,6 +298,15 @@ func (m *MachineManager) GetUserData(ctx context.Context) error {
 			Labels: map[string]string{
 				capi.ClusterLabelName: m.Machine.Spec.ClusterName,
 			},
+			OwnerReferences: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Controller: pointer.BoolPtr(true),
+					APIVersion: m.BareMetalMachine.APIVersion,
+					Kind: m.BareMetalMachine.Kind,
+					Name: m.BareMetalMachine.Name,
+					UID: m.BareMetalMachine.UID,
+				},
+			},
 		},
 		Data: map[string][]byte{
 			"userData": decodedUserDataBytes,

--- a/baremetal/baremetalmachine_manager_test.go
+++ b/baremetal/baremetalmachine_manager_test.go
@@ -1699,6 +1699,17 @@ var _ = Describe("BareMetalMachine manager", func() {
 				err = c.Get(context.TODO(), key, &tmpBootstrapSecret)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(tmpBootstrapSecret.Data["userData"])).To(Equal("FooBar\n"))
+				Expect(len(tmpBootstrapSecret.OwnerReferences)).To(Equal(1))
+				Expect(tmpBootstrapSecret.OwnerReferences[0].APIVersion).
+					To(Equal(tc.BMMachine.APIVersion))
+				Expect(tmpBootstrapSecret.OwnerReferences[0].Kind).
+					To(Equal(tc.BMMachine.Kind))
+				Expect(tmpBootstrapSecret.OwnerReferences[0].Name).
+					To(Equal(tc.BMMachine.Name))
+				Expect(tmpBootstrapSecret.OwnerReferences[0].UID).
+					To(Equal(tc.BMMachine.UID))
+				Expect(*tmpBootstrapSecret.OwnerReferences[0].Controller).
+					To(BeTrue())
 			}
 		},
 		Entry("Secret set in Machine", testCaseGetUserData{

--- a/baremetal/baremetalmachine_manager_test.go
+++ b/baremetal/baremetalmachine_manager_test.go
@@ -1699,7 +1699,7 @@ var _ = Describe("BareMetalMachine manager", func() {
 				err = c.Get(context.TODO(), key, &tmpBootstrapSecret)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(tmpBootstrapSecret.Data["userData"])).To(Equal("FooBar\n"))
-				Expect(len(tmpBootstrapSecret.OwnerReferences)).To(Equal(1))
+				Expect(len(tmpBootstrapSecret.OwnerReferences)).To(BeEquivalentTo(1))
 				Expect(tmpBootstrapSecret.OwnerReferences[0].APIVersion).
 					To(Equal(tc.BMMachine.APIVersion))
 				Expect(tmpBootstrapSecret.OwnerReferences[0].Kind).
@@ -1710,6 +1710,8 @@ var _ = Describe("BareMetalMachine manager", func() {
 					To(Equal(tc.BMMachine.UID))
 				Expect(*tmpBootstrapSecret.OwnerReferences[0].Controller).
 					To(BeTrue())
+				Expect(len(tmpBootstrapSecret.Finalizers)).To(Equal(1))
+				Expect(tmpBootstrapSecret.Finalizers).To(ContainElement(userDataFinalizer))
 			}
 		},
 		Entry("Secret set in Machine", testCaseGetUserData{
@@ -2134,8 +2136,9 @@ func newSecret() *corev1.Secret {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mybmmachine-user-data",
-			Namespace: "myns",
+			Name:       "mybmmachine-user-data",
+			Namespace:  "myns",
+			Finalizers: []string{"abcd"},
 		},
 		Data: map[string][]byte{
 			"userData": []byte("QmFyRm9vCg=="),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds ownerreferences and finalizers on the secrets that are created by CAPBM containing the userdata.