### PR TITLE
✨ Set ownerreference on BareMetalHost

### DIFF
--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -346,6 +346,7 @@ func (m *MachineManager) Delete(ctx context.Context) error {
 	}
 
 	if host != nil && host.Spec.ConsumerRef != nil {
+		host.OwnerReferences = m.DeleteOwnerRef(host.OwnerReferences)
 		// don't remove the ConsumerRef if it references some other bare metal machine
 		if !consumerRefMatches(host.Spec.ConsumerRef, m.BareMetalMachine) {
 			m.Log.Info("host already associated with another bare metal machine",
@@ -455,6 +456,15 @@ func (m *MachineManager) Update(ctx context.Context) error {
 	}
 	if host == nil {
 		return fmt.Errorf("host not found for machine %s", m.Machine.Name)
+	}
+
+	// ensure that the BMH specs are correctly set
+	err = m.setHostSpec(ctx, host)
+	if err != nil {
+		m.setError("Failed to associate the BaremetalHost to the BareMetalMachine",
+			capierrors.CreateMachineError,
+		)
+		return err
 	}
 
 	err = m.ensureAnnotation(ctx, host)
@@ -685,6 +695,8 @@ func (m *MachineManager) setHostSpec(ctx context.Context, host *bmh.BareMetalHos
 	}
 
 	host.Spec.Online = true
+	// Set OwnerReferences
+	host.OwnerReferences = m.SetOwnerRef(host.OwnerReferences, true)
 	return m.client.Update(ctx, host)
 }
 
@@ -836,4 +848,53 @@ func (m *MachineManager) SetNodeProviderID(ctx context.Context, bmhID, providerI
 func (m *MachineManager) SetProviderID(providerID string) {
 	m.BareMetalMachine.Spec.ProviderID = &providerID
 	m.BareMetalMachine.Status.Ready = true
+}
+
+// SetOwnerRef adds an ownerreference to this baremetal machine
+func (m *MachineManager) SetOwnerRef(refList []metav1.OwnerReference, controller bool) []metav1.OwnerReference {
+	index, err := m.FindOwnerRef(refList)
+	if err != nil {
+		refList = append(refList, metav1.OwnerReference{
+			APIVersion: m.BareMetalMachine.APIVersion,
+			Kind:       m.BareMetalMachine.Kind,
+			Name:       m.BareMetalMachine.Name,
+			UID:        m.BareMetalMachine.UID,
+			Controller: pointer.BoolPtr(controller),
+		})
+	} else {
+		refList[index].UID = m.BareMetalMachine.UID
+		refList[index].Controller = pointer.BoolPtr(controller)
+	}
+	return refList
+}
+
+// DeleteOwnerRef removes the ownerreference to this baremetal machine
+func (m *MachineManager) DeleteOwnerRef(refList []metav1.OwnerReference) []metav1.OwnerReference {
+	if len(refList) == 0 {
+		return refList
+	}
+	index, err := m.FindOwnerRef(refList)
+	if err != nil {
+		return refList
+	}
+	if len(refList) == 1 {
+		return []metav1.OwnerReference{}
+	}
+	refListLen := len(refList) - 1
+	refList[index] = refList[refListLen]
+	return (m.DeleteOwnerRef(refList[:refListLen-1]))
+}
+
+// FindOwnerRef checks if an ownerreference to this baremetal machine exists
+// and returns the index
+func (m *MachineManager) FindOwnerRef(refList []metav1.OwnerReference) (int, error) {
+	for i, curOwnerRef := range refList {
+		// not matching on UID since when pivoting it might change
+		if curOwnerRef.Name == m.BareMetalMachine.Name &&
+			curOwnerRef.APIVersion == m.BareMetalMachine.APIVersion &&
+			curOwnerRef.Kind == m.BareMetalMachine.Kind {
+			return i, nil
+		}
+	}
+	return 0, errors.New("OwnerRef not found")
 }

--- a/baremetal/baremetalmachine_manager_test.go
+++ b/baremetal/baremetalmachine_manager_test.go
@@ -619,6 +619,8 @@ var _ = Describe("BareMetalMachine manager", func() {
 			} else {
 				Expect(savedHost.Spec.UserData).To(BeNil())
 			}
+			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
+			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("User data has explicit alternate namespace", testCaseSetHostSpec{
 			UserDataNamespace:         "otherns",
@@ -1782,6 +1784,7 @@ var _ = Describe("BareMetalMachine manager", func() {
 		BMCSecret          *corev1.Secret
 		ExpectRequeue      bool
 		ExpectClusterLabel bool
+		ExpectOwnerRef     bool
 	}
 
 	DescribeTable("Test Associate function",
@@ -1804,23 +1807,33 @@ var _ = Describe("BareMetalMachine manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			err = machineMgr.Associate(context.TODO())
-			if !tc.ExpectRequeue {
-				Expect(err).NotTo(HaveOccurred())
-			} else {
+			if tc.ExpectRequeue {
 				_, ok := errors.Cause(err).(HasRequeueAfterError)
 				Expect(ok).To(BeTrue())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			if tc.Host == nil {
+				return
+			}
+			// get the saved host
+			savedHost := bmh.BareMetalHost{}
+			err = c.Get(context.TODO(),
+				client.ObjectKey{
+					Name:      tc.Host.Name,
+					Namespace: tc.Host.Namespace,
+				},
+				&savedHost,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = machineMgr.FindOwnerRef(savedHost.OwnerReferences)
+			if tc.ExpectOwnerRef {
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
 			}
 			if tc.ExpectClusterLabel {
-				// get the saved host
-				savedHost := bmh.BareMetalHost{}
-				err = c.Get(context.TODO(),
-					client.ObjectKey{
-						Name:      tc.Host.Name,
-						Namespace: tc.Host.Namespace,
-					},
-					&savedHost,
-				)
-				Expect(err).NotTo(HaveOccurred())
 				// get the BMC credential
 				savedCred := corev1.Secret{}
 				err = c.Get(context.TODO(),
@@ -1856,7 +1869,8 @@ var _ = Describe("BareMetalMachine manager", func() {
 				Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil,
 					false, false,
 				),
-				ExpectRequeue: false,
+				ExpectRequeue:  false,
+				ExpectOwnerRef: true,
 			},
 		),
 		Entry("Associate empty machine, host empty, baremetal machine spec set",
@@ -1865,8 +1879,9 @@ var _ = Describe("BareMetalMachine manager", func() {
 				BMMachine: newBareMetalMachine("mybmmachine", nil, bmmSpecAll(), nil,
 					bmmObjectMetaWithValidAnnotations(),
 				),
-				Host:          newBareMetalHost("", nil, bmh.StateNone, nil, false, false),
-				ExpectRequeue: false,
+				Host:           newBareMetalHost("", nil, bmh.StateNone, nil, false, false),
+				ExpectRequeue:  false,
+				ExpectOwnerRef: true,
 			},
 		),
 		Entry("Associate machine, host nil, baremetal machine spec set, requeue",
@@ -1887,6 +1902,7 @@ var _ = Describe("BareMetalMachine manager", func() {
 				BMCSecret:          newBMCSecret("mycredentials", false),
 				ExpectClusterLabel: true,
 				ExpectRequeue:      false,
+				ExpectOwnerRef:     true,
 			},
 		),
 	)
@@ -1920,6 +1936,216 @@ var _ = Describe("BareMetalMachine manager", func() {
 				bmmObjectMetaWithValidAnnotations(),
 			),
 			Host: newBareMetalHost("myhost", nil, bmh.StateNone, nil, false, false),
+		}),
+	)
+
+	type testCaseFindOwnerRef struct {
+		BMMachine     capbm.BareMetalMachine
+		OwnerRefs     []metav1.OwnerReference
+		ExpectError   bool
+		ExpectedIndex int
+	}
+
+	DescribeTable("Test FindOwnerRef",
+		func(tc testCaseFindOwnerRef) {
+			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.BMMachine,
+				klogr.New(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			index, err := machineMgr.FindOwnerRef(tc.OwnerRefs)
+			if tc.ExpectError {
+				Expect(err).NotTo(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(index).To(BeEquivalentTo(tc.ExpectedIndex))
+			}
+		},
+		Entry("Empty list", testCaseFindOwnerRef{
+			BMMachine:   *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs:   []metav1.OwnerReference{},
+			ExpectError: true,
+		}),
+		Entry("Absent", testCaseFindOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+			ExpectError: true,
+		}),
+		Entry("Present 0", testCaseFindOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+			ExpectError:   false,
+			ExpectedIndex: 0,
+		}),
+		Entry("Present 1", testCaseFindOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+			},
+			ExpectError:   false,
+			ExpectedIndex: 1,
+		}),
+	)
+
+	type testCaseOwnerRef struct {
+		BMMachine  capbm.BareMetalMachine
+		OwnerRefs  []metav1.OwnerReference
+		Controller bool
+	}
+
+	DescribeTable("Test DeleteOwnerRef",
+		func(tc testCaseOwnerRef) {
+			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.BMMachine,
+				klogr.New(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			refList := machineMgr.DeleteOwnerRef(tc.OwnerRefs)
+			_, err = machineMgr.FindOwnerRef(refList)
+			Expect(err).NotTo(BeNil())
+		},
+		Entry("Empty list", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{},
+		}),
+		Entry("Absent", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+		}),
+		Entry("Present 0", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+		}),
+		Entry("Present 1", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+			},
+		}),
+	)
+
+	DescribeTable("Test SetOwnerRef",
+		func(tc testCaseOwnerRef) {
+			machineMgr, err := NewMachineManager(nil, nil, nil, nil, &tc.BMMachine,
+				klogr.New(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			refList := machineMgr.SetOwnerRef(tc.OwnerRefs, tc.Controller)
+			index, err := machineMgr.FindOwnerRef(refList)
+			Expect(err).To(BeNil())
+			Expect(*refList[index].Controller).To(BeEquivalentTo(tc.Controller))
+		},
+		Entry("Empty list", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{},
+		}),
+		Entry("Absent", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+		}),
+		Entry("Present 0", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+			},
+		}),
+		Entry("Present 1", testCaseOwnerRef{
+			BMMachine: *newBareMetalMachine("myName", nil, nil, nil, nil),
+			OwnerRefs: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: "abc.com/v1",
+					Kind:       "def",
+					Name:       "ghi",
+					UID:        "adfasdf",
+				},
+				metav1.OwnerReference{
+					Kind:       "BMMachine",
+					APIVersion: capbm.GroupVersion.String(),
+					Name:       "myName",
+					UID:        "adfasdf",
+				},
+			},
 		}),
 	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an Ownerreference on the baremetalhost, set by CAPBM when selecting the baremetalhost. Clusterctl builds a tree of resources using the ownerreferences. the ownerreference is not directly used right now because we still have BMO installed out of the scope of clusterctl, but whenever that will not be the case anymore (i.e. we include BMO deployment in infrastructure-components.yaml) then this ownerreference is a must to ensure that the BMH gets moved along during the pivoting.