### PR TITLE
✨ Rename Provider from Baremetal to Metal3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ for testing purposes only, when Baremetal Operator is not deployed
     make deploy-bmo-cr
 ```
 
-### Deploy CAPBM CRDs
+### Deploy CAPM3 CRDs
 
-Deploys CAPBM CRDs
+Deploys CAPM3 CRDs
 
 ```sh
     make install
@@ -44,19 +44,19 @@ Deploys CAPBM CRDs
 
 ### Run locally
 
-Deploys CAPI, CABPK and CAPBM CRDs, runs CAPI and CABPK controllers in cluster
-and runs CAPBM controller locally
+Deploys CAPI, CABPK and CAPM3 CRDs, runs CAPI and CABPK controllers in cluster
+and runs CAPM3 controller locally
 
 ```sh
     make deploy
-    kubectl scale -n capbm-system deployment.v1.apps/capbm-controller-manager \
+    kubectl scale -n capm3-system deployment.v1.apps/capm3-controller-manager \
       --replicas 0
     make run
 ```
 
 ### Run in cluster
 
-Deploys CAPBM CRDs and controllers in cluster
+Deploys CAPM3 CRDs and controllers in cluster
 
 ```sh
     make deploy

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ but essentially, for any given release X.Y.Z:
 changes.
 
 These guarantees extend to all code exposed in public APIs of
-Cluster API Provider Baremetal. This includes code both in Cluster API Provider
+Cluster API Provider Metal3. This includes code both in Cluster API Provider
 Baremetal itself, *plus types from dependencies in public APIs*.  Types and
 functions not in public APIs are not considered part of the guarantee.
 
@@ -46,7 +46,7 @@ that we follow.
 
 ## Branches
 
-Cluster API Provider Baremetal contains two types of branches: the *master*
+Cluster API Provider Metal3 contains two types of branches: the *master*
 branch and *release-X* branches.
 
 The *master* branch is where development happens.  All the latest and
@@ -84,7 +84,7 @@ separately.
 
 ### Commands and Workflow
 
-Cluster API Provider Baremetal follows the standard Kubernetes workflow: any PR
+Cluster API Provider Metal3 follows the standard Kubernetes workflow: any PR
 needs `lgtm` and `approved` labels, PRs authors must have signed the CNCF CLA,
 and PRs must pass the tests before being merged.  See [the contributor
 docs](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-testing-and-merge-workflow)
@@ -94,7 +94,7 @@ We use the same priority and kind labels as Kubernetes.  See the labels
 tab in GitHub for the full list.
 
 The standard Kubernetes comment commands should work in
-Cluster API Provider Baremetal.  See [Prow](https://prow.k8s.io/command-help)
+Cluster API Provider Metal3.  See [Prow](https://prow.k8s.io/command-help)
 for a command reference.
 
 ## Release Process

--- a/baremetal/baremetalcluster_manager.go
+++ b/baremetal/baremetalcluster_manager.go
@@ -26,7 +26,7 @@ import (
 	// TODO Why blank import ?
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	capbm "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
+	capm3 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -49,14 +49,14 @@ type ClusterManager struct {
 	client client.Client
 
 	Cluster          *capi.Cluster
-	BareMetalCluster *capbm.BareMetalCluster
+	BareMetalCluster *capm3.BareMetalCluster
 	Log              logr.Logger
 	// name string
 }
 
 // NewClusterManager returns a new helper for managing a cluster with a given name.
 func NewClusterManager(client client.Client, cluster *capi.Cluster,
-	bareMetalCluster *capbm.BareMetalCluster,
+	bareMetalCluster *capm3.BareMetalCluster,
 	clusterLog logr.Logger) (ClusterManagerInterface, error) {
 
 	if bareMetalCluster == nil {
@@ -77,9 +77,9 @@ func NewClusterManager(client client.Client, cluster *capi.Cluster,
 // SetFinalizer sets finalizer
 func (s *ClusterManager) SetFinalizer() {
 	// If the BareMetalCluster doesn't have finalizer, add it.
-	if !util.Contains(s.BareMetalCluster.ObjectMeta.Finalizers, capbm.ClusterFinalizer) {
+	if !util.Contains(s.BareMetalCluster.ObjectMeta.Finalizers, capm3.ClusterFinalizer) {
 		s.BareMetalCluster.ObjectMeta.Finalizers = append(
-			s.BareMetalCluster.ObjectMeta.Finalizers, capbm.ClusterFinalizer,
+			s.BareMetalCluster.ObjectMeta.Finalizers, capm3.ClusterFinalizer,
 		)
 	}
 }
@@ -88,7 +88,7 @@ func (s *ClusterManager) SetFinalizer() {
 func (s *ClusterManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
 	s.BareMetalCluster.ObjectMeta.Finalizers = util.Filter(
-		s.BareMetalCluster.ObjectMeta.Finalizers, capbm.ClusterFinalizer,
+		s.BareMetalCluster.ObjectMeta.Finalizers, capm3.ClusterFinalizer,
 	)
 }
 
@@ -110,7 +110,7 @@ func (s *ClusterManager) Create(ctx context.Context) error {
 }
 
 // ControlPlaneEndpoint returns cluster controlplane endpoint
-func (s *ClusterManager) ControlPlaneEndpoint() ([]capbm.APIEndpoint, error) {
+func (s *ClusterManager) ControlPlaneEndpoint() ([]capm3.APIEndpoint, error) {
 	//Get IP address from spec, which gets it from posted cr yaml
 	endPoint := s.BareMetalCluster.Spec.ControlPlaneEndpoint
 	var err error
@@ -120,7 +120,7 @@ func (s *ClusterManager) ControlPlaneEndpoint() ([]capbm.APIEndpoint, error) {
 		return nil, err
 	}
 
-	return []capbm.APIEndpoint{
+	return []capm3.APIEndpoint{
 		{
 			Host: endPoint.Host,
 			Port: endPoint.Port,

--- a/baremetal/baremetalmachine_manager.go
+++ b/baremetal/baremetalmachine_manager.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	bmh "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
-	capbm "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
+	capm3 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -78,16 +78,16 @@ type MachineManager struct {
 	client client.Client
 
 	Cluster          *capi.Cluster
-	BareMetalCluster *capbm.BareMetalCluster
+	BareMetalCluster *capm3.BareMetalCluster
 	Machine          *capi.Machine
-	BareMetalMachine *capbm.BareMetalMachine
+	BareMetalMachine *capm3.BareMetalMachine
 	Log              logr.Logger
 }
 
 // NewMachineManager returns a new helper for managing a machine
 func NewMachineManager(client client.Client,
-	cluster *capi.Cluster, baremetalCluster *capbm.BareMetalCluster,
-	machine *capi.Machine, baremetalMachine *capbm.BareMetalMachine,
+	cluster *capi.Cluster, baremetalCluster *capm3.BareMetalCluster,
+	machine *capi.Machine, baremetalMachine *capm3.BareMetalMachine,
 	machineLog logr.Logger) (*MachineManager, error) {
 
 	return &MachineManager{
@@ -104,9 +104,9 @@ func NewMachineManager(client client.Client,
 // SetFinalizer sets finalizer
 func (m *MachineManager) SetFinalizer() {
 	// If the BareMetalMachine doesn't have finalizer, add it.
-	if !util.Contains(m.BareMetalMachine.Finalizers, capbm.MachineFinalizer) {
+	if !util.Contains(m.BareMetalMachine.Finalizers, capm3.MachineFinalizer) {
 		m.BareMetalMachine.Finalizers = append(m.BareMetalMachine.Finalizers,
-			capbm.MachineFinalizer,
+			capm3.MachineFinalizer,
 		)
 	}
 }
@@ -115,7 +115,7 @@ func (m *MachineManager) SetFinalizer() {
 func (m *MachineManager) UnsetFinalizer() {
 	// Cluster is deleted so remove the finalizer.
 	m.BareMetalMachine.Finalizers = util.Filter(m.BareMetalMachine.Finalizers,
-		capbm.MachineFinalizer,
+		capm3.MachineFinalizer,
 	)
 }
 
@@ -650,7 +650,7 @@ func (m *MachineManager) chooseHost(ctx context.Context) (*bmh.BareMetalHost, er
 
 // consumerRefMatches returns a boolean based on whether the consumer
 // reference and bare metal machine metadata match
-func consumerRefMatches(consumer *corev1.ObjectReference, bmmachine *capbm.BareMetalMachine) bool {
+func consumerRefMatches(consumer *corev1.ObjectReference, bmmachine *capm3.BareMetalMachine) bool {
 	if consumer.Name != bmmachine.Name {
 		return false
 	}

--- a/baremetal/manager_factory.go
+++ b/baremetal/manager_factory.go
@@ -18,17 +18,17 @@ package baremetal
 
 import (
 	"github.com/go-logr/logr"
-	capbm "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
+	capm3 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ManagerFactoryInterface interface {
 	NewClusterManager(cluster *capi.Cluster,
-		bareMetalCluster *capbm.BareMetalCluster,
+		bareMetalCluster *capm3.BareMetalCluster,
 		clusterLog logr.Logger) (ClusterManagerInterface, error)
-	NewMachineManager(*capi.Cluster, *capbm.BareMetalCluster, *capi.Machine,
-		*capbm.BareMetalMachine, logr.Logger) (MachineManagerInterface, error)
+	NewMachineManager(*capi.Cluster, *capm3.BareMetalCluster, *capi.Machine,
+		*capm3.BareMetalMachine, logr.Logger) (MachineManagerInterface, error)
 }
 
 // ManagerFactory only contains a client
@@ -42,15 +42,15 @@ func NewManagerFactory(client client.Client) ManagerFactory {
 }
 
 // NewClusterManager creates a new ClusterManager
-func (f ManagerFactory) NewClusterManager(cluster *capi.Cluster, capbmCluster *capbm.BareMetalCluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
-	return NewClusterManager(f.client, cluster, capbmCluster, clusterLog)
+func (f ManagerFactory) NewClusterManager(cluster *capi.Cluster, capm3Cluster *capm3.BareMetalCluster, clusterLog logr.Logger) (ClusterManagerInterface, error) {
+	return NewClusterManager(f.client, cluster, capm3Cluster, clusterLog)
 }
 
 // NewMachineManager creates a new MachineManager
 func (f ManagerFactory) NewMachineManager(capiCluster *capi.Cluster,
-	capbmCluster *capbm.BareMetalCluster,
-	capiMachine *capi.Machine, capbmMachine *capbm.BareMetalMachine,
+	capm3Cluster *capm3.BareMetalCluster,
+	capiMachine *capi.Machine, capm3Machine *capm3.BareMetalMachine,
 	machineLog logr.Logger) (MachineManagerInterface, error) {
-	return NewMachineManager(f.client, capiCluster, capbmCluster, capiMachine,
-		capbmMachine, machineLog)
+	return NewMachineManager(f.client, capiCluster, capm3Cluster, capiMachine,
+		capm3Machine, machineLog)
 }

--- a/baremetal/manager_factory_test.go
+++ b/baremetal/manager_factory_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	capbm "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
+	capm3 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	"k8s.io/klog/klogr"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,13 +43,13 @@ var _ = Describe("Manager factory testing", func() {
 
 	It("returns a cluster manager", func() {
 		_, err := managerFactory.NewClusterManager(&capi.Cluster{},
-			&capbm.BareMetalCluster{}, clusterLog,
+			&capm3.BareMetalCluster{}, clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("fails to return a cluster manager with nil cluster", func() {
-		_, err := managerFactory.NewClusterManager(nil, &capbm.BareMetalCluster{},
+		_, err := managerFactory.NewClusterManager(nil, &capm3.BareMetalCluster{},
 			clusterLog,
 		)
 		Expect(err).To(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("Manager factory testing", func() {
 
 	It("returns a machine manager", func() {
 		_, err := managerFactory.NewMachineManager(&capi.Cluster{},
-			&capbm.BareMetalCluster{}, &capi.Machine{}, &capbm.BareMetalMachine{},
+			&capm3.BareMetalCluster{}, &capi.Machine{}, &capm3.BareMetalMachine{},
 			clusterLog,
 		)
 		Expect(err).NotTo(HaveOccurred())

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Adds namespace to all resources.
-namespace: capbm-system
+namespace: capm3-system
 
 resources:
 - namespace.yaml

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,7 +1,7 @@
 namePrefix: capbm-
 
 commonLabels:
-  cluster.x-k8s.io/provider: "infrastructure-baremetal"
+  cluster.x-k8s.io/provider: "infrastructure-metal3"
 
 bases:
 - crd

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,4 +1,4 @@
-namePrefix: capbm-
+namePrefix: capm3-
 
 commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-metal3"

--- a/controllers/baremetalcluster_controller.go
+++ b/controllers/baremetalcluster_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	capbm "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
+	capm3 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	"github.com/metal3-io/cluster-api-provider-baremetal/baremetal"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/pointer"
@@ -62,7 +62,7 @@ func (r *BareMetalClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result,
 	clusterLog := log.Log.WithName(clusterControllerName).WithValues("baremetal-cluster", req.NamespacedName)
 
 	// Fetch the BareMetalCluster instance
-	baremetalCluster := &capbm.BareMetalCluster{}
+	baremetalCluster := &capm3.BareMetalCluster{}
 
 	if err := r.Client.Get(ctx, req.NamespacedName, baremetalCluster); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -169,12 +169,12 @@ func reconcileDelete(ctx context.Context,
 // SetupWithManager will add watches for this controller
 func (r *BareMetalClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&capbm.BareMetalCluster{}).
+		For(&capm3.BareMetalCluster{}).
 		Watches(
 			&source.Kind{Type: &capi.Cluster{}},
 			&handler.EnqueueRequestsFromMapFunc{
 				ToRequests: util.ClusterToInfrastructureMapFunc(
-					capbm.GroupVersion.WithKind("BareMetalCluster"),
+					capm3.GroupVersion.WithKind("BareMetalCluster"),
 				),
 			},
 		).

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ Metal3-io components are deployed :
 * Cluster API manager
 * Cluster API Bootstrap Provider Kubeadm (CABPK) manager
 * Baremetal Operator (including the Ironic setup)
-* Cluster API Provider Baremetal (CAPBM)
+* Cluster API Provider Metal3 (CAPM3)
 
 ## BareMetalHost
 
@@ -46,7 +46,7 @@ the cluster on Baremetal. It currently has two specification fields :
 * **apiEndpoint**: contains the target cluster API server address and port in
   URL format
 * **noCloudProvider**: (true/false) Whether the cluster will not be deployed
-  with an external cloud provider. If set to true, CAPBM will patch the target
+  with an external cloud provider. If set to true, CAPM3 will patch the target
   cluster node objects to add a providerID. This will allow the CAPI process to
   continue even if the cluster is deployed without cloud provider.
 
@@ -187,7 +187,7 @@ The fields are :
 * **userData** -- This includes two sub-fields, `name` and `namespace`, which
   reference a `Secret` that contains base64 encoded user-data to be written to
   a config drive on the provisioned `BareMetalHost`. This field is optional and
-  is automatically set by CAPBM with the userData from the machine object. If
+  is automatically set by CAPM3 with the userData from the machine object. If
   you want to overwrite the userData, this should be done in the CAPI machine.
 
 * **hostSelector** -- Specify criteria for matching labels on `BareMetalHost`

--- a/docs/deployment_workflow.md
+++ b/docs/deployment_workflow.md
@@ -6,7 +6,7 @@ The following controllers need to be deployed :
 
 * CAPI
 * CAPBK or alternative
-* CAPBM
+* CAPM3
 * Baremetal Operator, with Ironic setup
 
 ## Requirements
@@ -35,7 +35,7 @@ An outline of the workflow is below.
 
 1. The CAPI controller will set the OwnerRef on the BaremetalCluster referenced
    by the Cluster
-1. The CAPBM controller will verify the apiEndpoint field and populate the
+1. The CAPM3 controller will verify the apiEndpoint field and populate the
    status with ready field set to true and apiEndpoint to the content of
    apiEndpoint.
 1. The CAPI controller will set infrastructureReady field to true on the Cluster
@@ -48,13 +48,13 @@ An outline of the workflow is below.
 1. The CAPI controller will copy the userData output into the userData field of
    the machine object and set the bootstrapReady field to true.
 1. Once the machine has userdata, OwnerRef and bootstrapReady properly set, the
-   CAPBM controller will select, if possible, a BareMetalHost that matches the
-   criteria, or wait until one is available. If matched, the CAPBM controller
+   CAPM3 controller will select, if possible, a BareMetalHost that matches the
+   criteria, or wait until one is available. If matched, the CAPM3 controller
    will create a secret with the userData. and set the BareMetalHost spec
    accordingly to the BareMetalMachine specs.
 1. The BareMetal Operator will then start the deployment.
 1. After deployment, the BaremetalHost will be in provisioned state. However,
-   initialization is not complete. If deploying without cloud provider, CAPBM
+   initialization is not complete. If deploying without cloud provider, CAPM3
    will wait until the target cluster is up and the node appears. It will fetch
    the node by matching the label `metal3.io/uuid=<bmh-uuid>`. It will set the
    providerID to `metal3://<bmh-uuid>`. The BareMetalMachine ready status will

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -58,7 +58,7 @@ the requested CRDs.
 You will first need to scale down the controller deployment :
 
 ```sh
-    kubectl scale -n capbm-system deployment.v1.apps/capbm-controller-manager \
+    kubectl scale -n capm3-system deployment.v1.apps/capm3-controller-manager \
       --replicas 0
 ```
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -2,7 +2,7 @@
 
 ## Pre-requisites
 
-CAPBM requires two external tools for running the tests
+CAPM3 requires two external tools for running the tests
 during development.
 
 ### Install kustomize
@@ -44,9 +44,9 @@ Refer to the [baremetal-operator developer
 documentation](https://github.com/metal3-io/baremetal-operator/blob/master/docs/dev-setup.md)
 for instructions and tools for creating BareMetalHost objects.
 
-### Deploy CAPI and CAPBM
+### Deploy CAPI and CAPM3
 
-The following command will deploy the controllers from CAPI, CABPK and CAPBM and
+The following command will deploy the controllers from CAPI, CABPK and CAPM3 and
 the requested CRDs.
 
 ```sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ This provider integrates with the
 
 ### Pre-requisites
 
-The pre-requisite for the deployment of CAPBM are the following:
+The pre-requisite for the deployment of CAPM3 are the following:
 
 - [Baremetal-Operator](https://github.com/metal3-io/baremetal-operator) deployed
 - Ironic up and running (inside or outside of the cluster)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
-# CAPBM testing
+# CAPM3 testing
 
-This document outlines the testing strategy applied in CAPBM. All developers
+This document outlines the testing strategy applied in CAPM3. All developers
 should follow those guidelines to ensure uniformity and quality in the tests.
 
 ## Code coverage

--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -2,8 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capbm-controller-manager
-  namespace: capbm-system
+  name: capm3-controller-manager
+  namespace: capm3-system
 spec:
   template:
     spec:

--- a/hack/kind/start_controllers.sh
+++ b/hack/kind/start_controllers.sh
@@ -25,9 +25,9 @@ fi
 kind load docker-image gcr.io/arvinders-1st-project/cluster-api-kubeadm-controller-amd64:dev
 make deploy
 
-# CAPBM
+# CAPM3
 cd ~/go/src/github.com/metal3-io/cluster-api-provider-baremetal
-if [ -n "${BUILD_CAPBM}" ]; then
+if [ -n "${BUILD_CAPM3}" ]; then
 	make docker-build
 fi
 kind load docker-image controller:dev

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&watchNamespace, "namespace", "",
-		"Namespace that the controller watches to reconcile CAPBM objects. If unspecified, the controller watches for CAPBM objects across all namespaces.")
+		"Namespace that the controller watches to reconcile CAPM3 objects. If unspecified, the controller watches for CAPM3 objects across all namespaces.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 	flag.IntVar(&webhookPort, "webhook-port", 0,
@@ -84,7 +84,7 @@ func main() {
 		Scheme:                 myscheme,
 		MetricsBindAddress:     metricsAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "controller-leader-election-capbm",
+		LeaderElectionID:       "controller-leader-election-CAPM3",
 		SyncPeriod:             &syncPeriod,
 		Port:                   webhookPort,
 		HealthProbeBindAddress: healthAddr,

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 	infrav1alpha2 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha2"
 	infrav1 "github.com/metal3-io/cluster-api-provider-baremetal/api/v1alpha3"
 	"github.com/metal3-io/cluster-api-provider-baremetal/baremetal"
-	capbmremote "github.com/metal3-io/cluster-api-provider-baremetal/baremetal/remote"
+	capm3remote "github.com/metal3-io/cluster-api-provider-baremetal/baremetal/remote"
 	"github.com/metal3-io/cluster-api-provider-baremetal/controllers"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -160,7 +160,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 		Client:           mgr.GetClient(),
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
 		Log:              ctrl.Log.WithName("controllers").WithName("BareMetalMachine"),
-		CapiClientGetter: capbmremote.NewClusterClient,
+		CapiClientGetter: capm3remote.NewClusterClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BareMetalMachineReconciler")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is related to an issue in CAPI about renaming
Metal3.io provider from baremetal to metal3. It renames the provider from CAPBM to CAPM3. It is mostly cosmetic changes, except for the config/ folder that will modify the deployment (namespace and naming). No break in backwards compatibility.

**Which issue(s) this PR fixes**:
Fixes #267
