### PR TITLE
🐛 Fix leader election configmap name

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 		Scheme:                 myscheme,
 		MetricsBindAddress:     metricsAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "controller-leader-election-CAPM3",
+		LeaderElectionID:       "controller-leader-election-capm3",
 		SyncPeriod:             &syncPeriod,
 		Port:                   webhookPort,
 		HealthProbeBindAddress: healthAddr,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the leader election configmap name
